### PR TITLE
Fix annoying spelling mistake in Install command: DESTDIT => DESTDIR

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Installation
 ============
 
 ```
-make SDL_PLATFORM=linux SDL_BUILD=static SDL_MODE=release DESTDIT=/myprefix install
+make SDL_PLATFORM=linux SDL_BUILD=static SDL_MODE=release DESTDIR=/myprefix install
 ```
 
 Copyright


### PR DESCRIPTION
I know it's a super simple change, but I spent 5 min being annoyed by it, and thought it worth changing.