### PR TITLE
Read game controller mappings from file.

### DIFF
--- a/src/sdl-inputs-joysticks-game_controllers.ads
+++ b/src/sdl-inputs-joysticks-game_controllers.ads
@@ -67,7 +67,7 @@ package SDL.Inputs.Joysticks.Game_Controllers is
    Null_Game_Controller : constant Game_Controller;
 
    procedure Add_Mapping (Data : in String; Updated_Existing : out Boolean);
-   function Add_Mapping (Database_Filename : in String) return Natural;  --  From v2.0.2
+   procedure Add_Mappings_From_File (Database_Filename : in String; Number_Added : out Natural);
 
    function Axis_Value (Self : in Game_Controller;
                         Axis : in SDL.Events.Joysticks.Game_Controllers.LR_Axes)


### PR DESCRIPTION
At present, the function form of `Add_Mapping` claims to read mappings from a file, but in fact just reads a single entry.

This patch replaces the function form with `Add_Mappings_From_File`.

Also, the old procedural form of `Add_Mapping` didn’t write the `Updated_Existing` `out` parameter (to `False`) if the mapping was new.

Note: `Add_Mappings_From_File` only counts the number of new mappings. Not sure what happens if some are actually changed.

  * src/sdl-inputs-joysticks-game_controllers.ads (Add_Mapping): Now a
      single procedure with an out parameter to indicate whether an
      existing mapping was updated.
    (Add_Mappings_From_File): New. Replaces the old function
      Add_Mapping; has an out parameter to indicate the number of
      mappings added.
  * src/sdl-inputs-joysticks-game_controllers.adb (context): Add
      SDL.RWops.
    (Add_Mapping): Updated_Existing wasn't written if there was no
      existing mapping.
    (Add_Mappings_From_File): New. Explicit coding of the C macro
      SDL_GameControllerAddMappingsFromFile().