### PR TITLE
Added SDL.Events.Events.Wait (cf Poll).

### DIFF
--- a/src/sdl-events-events.adb
+++ b/src/sdl-events-events.adb
@@ -21,6 +21,7 @@
 --     distribution.
 --------------------------------------------------------------------------------------------------------------------
 with Interfaces.C;
+with SDL.Error;
 
 package body SDL.Events.Events is
    function Poll (Event : out Events) return Boolean is
@@ -39,4 +40,19 @@ package body SDL.Events.Events is
 
       return False;
    end Poll;
+
+   procedure Wait (Event : out Events) is
+      --  int SDL_WaitEvent(SDL_Event *event);
+
+      use type Interfaces.C.int;
+      function SDL_Wait_Event (Event : out Events) return Interfaces.C.int
+      with
+        Import        => True,
+        Convention    => C,
+        External_Name => "SDL_WaitEvent";
+   begin
+      if SDL_Wait_Event (Event) = 0 then
+         raise Event_Error with SDL.Error.Get;
+      end if;
+   end Wait;
 end SDL.Events.Events;

--- a/src/sdl-events-events.ads
+++ b/src/sdl-events-events.ads
@@ -127,9 +127,9 @@ package SDL.Events.Events is
 
    --  Poll for currently pending events.
    --
-   --  If there are any pending events, the next event is removed from
-   --  the queue and stored in Event, and then this returns
-   --  True. Otherwise, this does nothing and returns False.
+   --  If the are any pending events, the next event is removed from the queue
+   --  and stored in Event, and then this returns True. Otherwise, this does
+   --  nothing and returns False.
    function Poll (Event : out Events) return Boolean;
 
    --  Wait until an event is pending.

--- a/src/sdl-events-events.ads
+++ b/src/sdl-events-events.ads
@@ -122,11 +122,20 @@ package SDL.Events.Events is
      Unchecked_Union,
      Convention => C;
 
+   --  Some error occurred while polling/waiting for events.
+   Event_Error : exception;
+
    --  Poll for currently pending events.
    --
-   --  If the are any pending events, the next event is removed from the queue
-   --  and stored in Event, and then this returns True. Otherwise, this does
-   --  nothing and returns False.
+   --  If there are any pending events, the next event is removed from
+   --  the queue and stored in Event, and then this returns
+   --  True. Otherwise, this does nothing and returns False.
    function Poll (Event : out Events) return Boolean;
+
+   --  Wait until an event is pending.
+   --
+   --  If there are any pending events, the next event is removed from
+   --  the queue and stored in Event.
+   procedure Wait (Event : out Events);
 
 end SDL.Events.Events;


### PR DESCRIPTION
I needed a Wait equivalent of Poll, since I have nothing else to do in the main loop.
I see I re-formatted the comment on Poll - OK? (I’m using Emacs with 79-column lines :-)
I realise this would need to be folded into Issue #13, hope that won’t conflict.

  * src/sdl-events-events.ads (Event_Error): new exception.
    (Wait): new.
  * src/sdl-events-events.adb (Wait): new. Raises Event_Error on error.