### PR TITLE
Change C includes to add the SDL2 root dir

### DIFF
--- a/build/gnat/sdlada.gpr
+++ b/build/gnat/sdlada.gpr
@@ -35,7 +35,7 @@ library project SDLAda is
       --  These flags require checking on all platforms as they're taken directly from sdl2-config.
       case Platform is
          when "linux" | "bsd" | "android" | "windows" =>
-            C_Switches   := C_Switches & ("-I/usr/include/SDL2", "-D_REENTRANT");
+            C_Switches   := C_Switches & ("-I/usr/include/", "-D_REENTRANT");
 
          when others =>
             null;

--- a/src/image/version_images.c
+++ b/src/image/version_images.c
@@ -23,7 +23,7 @@
 #ifdef __APPLE__
 #include <SDL2_image/SDL_image.h>
 #else
-#include <SDL_image.h>
+#include <SDL2/SDL_image.h>
 #endif
 
 /* We need to define some constants here so we can get access to the values that in #define form from Ada.

--- a/src/sdl-video-gl.adb
+++ b/src/sdl-video-gl.adb
@@ -483,13 +483,13 @@ package body SDL.Video.GL is
          raise SDL_GL_Error with SDL.Error.Get;
       end if;
 
-      Result := SDL_GL_Get_Attribute (Attribute_Context_Major_Version, C.int (Major));
+      Result := SDL_GL_Set_Attribute (Attribute_Context_Major_Version, C.int (Major));
 
       if Result /= Success then
          raise SDL_GL_Error with SDL.Error.Get;
       end if;
 
-      Result := SDL_GL_Get_Attribute (Attribute_Context_Minor_Version, C.int (Minor));
+      Result := SDL_GL_Set_Attribute (Attribute_Context_Minor_Version, C.int (Minor));
 
       if Result /= Success then
          raise SDL_GL_Error with SDL.Error.Get;

--- a/src/ttf/version_ttf.c
+++ b/src/ttf/version_ttf.c
@@ -23,7 +23,7 @@
 #ifdef __APPLE__
 #include <SDL2_ttf/SDL_ttf.h>
 #else
-#include <SDL_ttf.h>
+#include <SDL2/SDL_ttf.h>
 #endif
 
 /* We need to define some constants here so we can get access to the values that in #define form from Ada.

--- a/src/version.c
+++ b/src/version.c
@@ -20,11 +20,7 @@
  *    3. This notice may not be removed or altered from any source
  *    distribution.
  **********************************************************************************************************************/
-#ifdef __APPLE__
 #include <SDL2/SDL.h>
-#else
-#include <SDL.h>
-#endif
 
 /* We need to define some constants here so we can get access to the values that in #define form from Ada.
  */


### PR DESCRIPTION
Hi @Lucretia,

I am working on Alire for Windows, and in particular integrating the [msys2](https://www.msys2.org/) ecosystem. It will allow us to install dependencies (e.g. libsdl2) like we would do with Linux system package managers.

I have a problem right now with the includes in `src/version.c`, `src/image/version_images.c` and `src/ttf/version_ttf.c`.

`sdlada.gpr` has the `-I/use/include/SDL2` compiler switch but it doesn't work because of the UNIX path. However if we add the `SDL2/` root dir to every include it fixes the problem. Let me know if that works for you.

I also have a patch to fix typos in sdl-video-gl.adb.