### PR TITLE
Reduce use of with Interfaces

### DIFF
--- a/src/sdl-video-pixel_formats.ads
+++ b/src/sdl-video-pixel_formats.ads
@@ -33,6 +33,8 @@ with SDL.Video.Palettes;
 package SDL.Video.Pixel_Formats is
    package C renames Interfaces.C;
 
+   subtype Unsigned_32 is Interfaces.Unsigned_32;
+
    type Pixel_Types is
      (Unknown,
       Index_1,


### PR DESCRIPTION
By subtyping Unsigned_32 the user do not need to with Interfaces when using To_Pixel.