### PR TITLE
Fixed unit test (suspected typo).

### DIFF
--- a/unit_tests/pixel_format_test_cases.adb
+++ b/unit_tests/pixel_format_test_cases.adb
@@ -353,7 +353,7 @@ package body Pixel_Format_Test_Cases is
       begin
          --  Put_Line (Error);
 
-         Assert (To_int (Pixel_Format_ARGB_8888) /= C_ARGB_8888, Error);
+         Assert (To_int (Pixel_Format_ARGB_8888) = C_ARGB_8888, Error);
       end;
 
       declare


### PR DESCRIPTION
Unit test fails, because the values are actually equal. Considering that all the other tests are comparing for equality, not inequality, I suspect a typo here.

With this fix, the unit tests run w/o failure again.