### PR TITLE
Add basic Audio support

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ SDL_AtomicSet                         |   n   |
 SDL_AtomicSetPtr                      |   n   |
 SDL_AtomicTryLock                     |   n   |
 SDL_AtomicUnlock                      |   n   |
-SDL_AudioInit                         |   n   |
+SDL_AudioInit                         |   y   |
 SDL_AudioQuit                         |   n   |
 SDL_BlitScaled                        |   y   |
 SDL_BlitSurface                       |   y   |
@@ -134,9 +134,9 @@ SDL_CalculateGammaRamp                |   y   |
 SDL_CaptureMouse                      |   y   |
 SDL_ClearError                        |   y   |
 SDL_ClearHints                        |   y   |
-SDL_ClearQueuedAudio                  |   n   |
+SDL_ClearQueuedAudio                  |   y   |
 SDL_CloseAudio                        |   n   |
-SDL_CloseAudioDevice                  |   n   |
+SDL_CloseAudioDevice                  |   y   |
 SDL_CompilerBarrier                   |   n   |
 SDL_CondBroadcast                     |   n   |
 SDL_CondSignal                        |   n   |
@@ -230,9 +230,9 @@ SDL_GameControllerOpen                |   y   |
 SDL_GameControllerUpdate              |   y   |
 SDL_GetAssertionHandler               |   n   |
 SDL_GetAssertionReport                |   n   |
-SDL_GetAudioDeviceName                |   n   |
-SDL_GetAudioDeviceStatus              |   n   |
-SDL_GetAudioDriver                    |   n   |
+SDL_GetAudioDeviceName                |   y   |
+SDL_GetAudioDeviceStatus              |   y   |
+SDL_GetAudioDriver                    |   y   |
 SDL_GetAudioStatus                    |   n   |
 SDL_GetBasePath                       |   y   |
 SDL_GetCPUCacheLineSize               |   y   |
@@ -241,7 +241,7 @@ SDL_GetClipRect                       |   y   |
 SDL_GetClipboardText                  |   y   |
 SDL_GetClosestDisplayMode             |   y   |
 SDL_GetColorKey                       |   y   |
-SDL_GetCurrentAudioDriver             |   n   |
+SDL_GetCurrentAudioDriver             |   y   |
 SDL_GetCurrentDisplayMode             |   y   |
 SDL_GetCurrentVideoDriver             |   y   |
 SDL_GetCursor                         |   y   |
@@ -263,8 +263,8 @@ SDL_GetKeyboardState                  |   n   |
 SDL_GetModState                       |   y   |
 SDL_GetMouseFocus                     |   n   |
 SDL_GetMouseState                     |   y   |
-SDL_GetNumAudioDevices                |   n   |
-SDL_GetNumAudioDrivers                |   n   |
+SDL_GetNumAudioDevices                |   y   |
+SDL_GetNumAudioDrivers                |   y   |
 SDL_GetNumDisplayModes                |   y   |
 SDL_GetNumRenderDrivers               |   y   |
 SDL_GetNumTouchDevices                |   n   |
@@ -277,7 +277,7 @@ SDL_GetPixelFormatName                |   y   |
 SDL_GetPlatform                       |   n   |      *
 SDL_GetPowerInfo                      |   y   |
 SDL_GetPrefPath                       |   y   |
-SDL_GetQueuedAudioSize                |   n   |
+SDL_GetQueuedAudioSize                |   y   |
 SDL_GetRGB                            |   y   |
 SDL_GetRGBA                           |   y   |
 SDL_GetRelativeMouseMode              |   y   |
@@ -441,9 +441,9 @@ SDL_MouseIsHaptic                     |   n   |
 SDL_NumHaptics                        |   n   |
 SDL_NumJoysticks                      |   y   |
 SDL_OpenAudio                         |   n   |
-SDL_OpenAudioDevice                   |   n   |
+SDL_OpenAudioDevice                   |   y   |
 SDL_PauseAudio                        |   n   |
-SDL_PauseAudioDevice                  |   n   |
+SDL_PauseAudioDevice                  |   y   |
 SDL_PeepEvents                        |   n   |
 SDL_PixelFormatEnumToMasks            |   y   |
 SDL_PointInRect                       |   n   |

--- a/build/gnat/tests.gpr
+++ b/build/gnat/tests.gpr
@@ -6,7 +6,7 @@ project Tests is
    for Exec_Dir    use "gen/" & SDLAda.Mode & "/test";
    for Main        use ("test.adb", "version.adb", "platform.adb", "error.adb", "libraries.adb", "clipboard.adb",
                         "stream.adb", "stream2.adb", "surface.adb", "rwops.adb", "timers.adb", "create_window.adb",
-                        "mouse.adb",
+                        "mouse.adb", "audio.adb",
 
                         --  For SDL.Image.
                         "load_surface.adb",

--- a/build/gnat/tests.gpr
+++ b/build/gnat/tests.gpr
@@ -24,7 +24,9 @@ project Tests is
          when "macos_homebrew" =>
             Linker_Switches := Linker_Switches & ("-lSDL2",
                                                   "-lSDL2_ttf",
-                                                  "-lSDL2_image");
+                                                  "-lSDL2_image",
+                                                  "-L/usr/local/lib");
+
          when others =>
             null;
       end case;

--- a/src/sdl-audio-devices.adb
+++ b/src/sdl-audio-devices.adb
@@ -1,0 +1,311 @@
+--------------------------------------------------------------------------------------------------------------------
+--  Copyright (c) 2021, Eduard Llamosí
+--
+--  This software is provided 'as-is', without any express or implied
+--  warranty. In no event will the authors be held liable for any damages
+--  arising from the use of this software.
+--
+--  Permission is granted to anyone to use this software for any purpose,
+--  including commercial applications, and to alter it and redistribute it
+--  freely, subject to the following restrictions:
+--
+--     1. The origin of this software must not be misrepresented; you must not
+--     claim that you wrote the original software. If you use this software
+--     in a product, an acknowledgment in the product documentation would be
+--     appreciated but is not required.
+--
+--     2. Altered source versions must be plainly marked as such, and must not be
+--     misrepresented as being the original software.
+--
+--     3. This notice may not be removed or altered from any source
+--     distribution.
+--------------------------------------------------------------------------------------------------------------------
+with Interfaces.C.Strings;
+with SDL.Error;
+with Ada.Unchecked_Conversion;
+
+package body SDL.Audio.Devices is
+   package C renames Interfaces.C;
+
+   function Total_Devices
+     (Is_Capture : in Boolean := False)
+      return Positive
+   is
+      function SDL_Get_Num_Audio_Devices
+        (Is_Capture : in SDL_Bool)
+         return C.int
+        with
+          Import        => True,
+          Convention    => C,
+          External_Name => "SDL_GetNumAudioDevices";
+
+      Num : constant C.int := SDL_Get_Num_Audio_Devices (To_Bool (Is_Capture));
+   begin
+      if Num < 0 then
+         raise Audio_Device_Error with SDL.Error.Get;
+      end if;
+
+      return Positive (Num);
+   end Total_Devices;
+
+   function Get_Name
+     (Index      : in Positive;
+      Is_Capture : in Boolean := False)
+      return String
+   is
+      function SDL_Get_Audio_Device_Name
+        (Index : in C.int; Is_Capture : in SDL_Bool)
+         return C.Strings.chars_ptr
+        with
+          Import        => True,
+          Convention    => C,
+          External_Name => "SDL_GetAudioDeviceName";
+
+      --  Index is zero based, so need to subtract 1 to correct it.
+      C_Str : constant C.Strings.chars_ptr := SDL_Get_Audio_Device_Name
+        (C.int (Index) - 1, To_Bool (Is_Capture));
+   begin
+      return C.Strings.Value (C_Str);
+   end Get_Name;
+
+   function Open
+     (Name            : in String := "";
+      Is_Capture      : in Boolean := False;
+      Desired         : in Desired_Spec;
+      Obtained        : out Obtained_Spec;
+      Callback        : in Audio_Callback := null;
+      User_Data       : in User_Data_Access := null;
+      Allowed_Changes : in Changes := None)
+      return Device
+   is
+   begin
+      return Result : Device do
+         Open
+           (Result, Name, Is_Capture, Desired,
+            Obtained, Callback, User_Data, Allowed_Changes);
+      end return;
+   end Open;
+
+   procedure Open
+     (Self            : out Device;
+      Name            : in String := "";
+      Is_Capture      : in Boolean := False;
+      Desired         : in Desired_Spec;
+      Obtained        : out Obtained_Spec;
+      Callback        : in Audio_Callback := null;
+      User_Data       : in User_Data_Access := null;
+      Allowed_Changes : in Changes := None)
+   is
+      function SDL_Open_Audio_Device
+        (C_Name     : in C.Strings.chars_ptr;
+         Is_Capture : in SDL_Bool;
+         D          : in Internal_Spec_Ptr;
+         O          : in Internal_Spec_Ptr;
+         AC         : in Changes)
+         return C.int
+        with
+          Import        => True,
+          Convention    => C,
+          External_Name => "SDL_OpenAudioDevice";
+
+      Desired_Internal, Obtained_Internal : aliased Internal_Spec;
+
+      C_Str  : C.Strings.chars_ptr := C.Strings.Null_Ptr;
+      Num : C.int;
+   begin
+      Desired_Internal :=
+        To_Internal_Spec
+          (From     => Desired,
+           Callback => Callback,
+           External => Self.External'Unchecked_Access);
+
+      if Name /= "" then
+         C_Str := C.Strings.New_String (Name);
+
+         Num := SDL_Open_Audio_Device
+           (C_Name     => C_Str,
+            Is_Capture => To_Bool (Is_Capture),
+            D          => Desired_Internal'Unrestricted_Access,
+            O          => Obtained_Internal'Unchecked_Access,
+            AC         => Allowed_Changes);
+
+         C.Strings.Free (C_Str);
+      else
+         Num := SDL_Open_Audio_Device
+           (C_Name     => C.Strings.Null_Ptr,
+            Is_Capture => To_Bool (Is_Capture),
+            D          => Desired_Internal'Unrestricted_Access,
+            O          => Obtained_Internal'Unchecked_Access,
+            AC         => Allowed_Changes);
+      end if;
+
+      Obtained := To_External_Spec (Obtained_Internal);
+
+      if Num < 0 then -- Will alwats be >= 2 if successful
+         raise Audio_Device_Error with SDL.Error.Get;
+      end if;
+
+      Internal_Open (Self, Num, Callback, User_Data);
+   end Open;
+
+   procedure Queue
+     (Self : in Device;
+      Data : aliased in Buffer_Type)
+   is
+      use Interfaces;
+
+      function SDL_Queue_Audio
+        (Dev  : in ID;
+         Data : in System.Address;
+         Len  : in Interfaces.Unsigned_32)
+         return C.int
+        with
+          Import        => True,
+          Convention    => C,
+          External_Name => "SDL_QueueAudio";
+
+      Num : C.int;
+   begin
+      Num := SDL_Queue_Audio
+        (Dev  => Self.Internal,
+         Data => Data (Data'First)'Address,
+         Len  => Data'Size / System.Storage_Unit);
+
+      if Num < 0 then
+         raise Audio_Device_Error with SDL.Error.Get;
+      end if;
+   end Queue;
+
+   procedure Internal_Callback
+     (External    : in External_Data_Ptr;
+      Data        : in System.Address;
+      Byte_Length : in Positive)
+   is
+      Frame_Size  : constant Positive := Frame_Type'Size / System.Storage_Unit;
+      Frame_Count : constant Positive := Byte_Length / Frame_Size;
+
+      First_Index : constant Buffer_Index := Buffer_Index'First;
+      Last_Index  : constant Buffer_Index := Buffer_Index'Val (Frame_Count);
+
+      subtype Constrained_Buffer is Buffer_Type (First_Index .. Last_Index);
+      type Constrained_Buffer_Ptr is access Constrained_Buffer;
+
+      function To_Ada_Array is new Ada.Unchecked_Conversion
+        (Source => System.Address,
+         Target => Constrained_Buffer_Ptr);
+
+      Ada_Array : constant Constrained_Buffer_Ptr := To_Ada_Array (Data);
+   begin
+      External.Callback (External.User_Data, Ada_Array.all);
+   end Internal_Callback;
+
+   function Get_Status (Self : in Device) return Audio_Status is
+      function SDL_Get_Audio_Device_Status (Dev : in ID) return Audio_Status
+        with
+          Import        => True,
+          Convention    => C,
+          External_Name => "SDL_GetAudioDeviceStatus";
+   begin
+      return SDL_Get_Audio_Device_Status (Self.Internal);
+   end Get_Status;
+
+   function Get_ID (Self : in Device) return ID is
+   begin
+      return Self.Internal;
+   end Get_ID;
+
+   procedure Pause (Self : in Device; Pause : in Boolean) is
+      procedure SDL_Pause_Audio_Device (Dev : in ID; P : in SDL_Bool)
+      with
+        Import        => True,
+        Convention    => C,
+        External_Name => "SDL_PauseAudioDevice";
+   begin
+      SDL_Pause_Audio_Device (Self.Internal, To_Bool (Pause));
+   end Pause;
+
+   function Get_Queued_Size (Self : in Device) return Interfaces.Unsigned_32 is
+      function SDL_Get_Queued_Audio_Size (Dev : in ID)
+         return Interfaces.Unsigned_32
+      with
+        Import        => True,
+        Convention    => C,
+        External_Name => "SDL_GetQueuedAudioSize";
+   begin
+      return SDL_Get_Queued_Audio_Size (Self.Internal);
+   end Get_Queued_Size;
+
+   procedure Clear_Queued (Self : in Device) is
+      procedure SDL_Clear_Queued_Audio (Dev : in ID)
+      with
+        Import        => True,
+        Convention    => C,
+        External_Name => "SDL_ClearQueuedAudio";
+   begin
+      SDL_Clear_Queued_Audio (Self.Internal);
+   end Clear_Queued;
+
+   procedure Close (Self : in out Device) is
+      procedure SDL_Close_Audio_Device (Dev : in ID)
+      with
+        Import        => True,
+        Convention    => C,
+        External_Name => "SDL_CloseAudioDevice";
+   begin
+      SDL_Close_Audio_Device (Self.Internal);
+      Self.Is_Open := False;
+   end Close;
+
+   procedure Internal_Open
+     (Self      : out Device;
+      Num       : in C.int;
+      Callback  : in Audio_Callback;
+      User_Data : in User_Data_Access)
+   is
+   begin
+      Self.Internal := ID (Num);
+      Self.Is_Open := True;
+      Self.External.Callback := Callback;
+      Self.External.User_Data := User_Data;
+   end Internal_Open;
+
+   function To_Internal_Spec
+     (From     : in Desired_Spec;
+      Callback : in Audio_Callback;
+      External : in External_Data_Ptr)
+      return Internal_Spec is
+   begin
+      return Result : Internal_Spec do
+         Result.Frequency := From.Frequency;
+         Result.Format    := From.Format;
+         Result.Channels  := From.Channels;
+         Result.Samples   := From.Samples;
+         Result.Callback  :=
+           (if Callback /= null then Internal_Callback'Access else null);
+         Result.User_Data := External;
+      end return;
+   end To_Internal_Spec;
+
+   function To_External_Spec (From : Internal_Spec) return Obtained_Spec is
+   begin
+      return Result : Obtained_Spec do
+         Result :=
+           (Mode      => Obtained,
+            Frequency => From.Frequency,
+            Format    => From.Format,
+            Channels  => From.Channels,
+            Samples   => From.Samples,
+            Silence   => From.Silence,
+            Size      => From.Size);
+      end return;
+   end To_External_Spec;
+
+   overriding
+   procedure Finalize (Self : in out Device) is
+   begin
+      if Self.Is_Open then
+         Self.Close;
+      end if;
+   end Finalize;
+
+end SDL.Audio.Devices;

--- a/src/sdl-audio-devices.ads
+++ b/src/sdl-audio-devices.ads
@@ -1,0 +1,209 @@
+--------------------------------------------------------------------------------------------------------------------
+--  Copyright (c) 2021, Eduard Llamosí
+--
+--  This software is provided 'as-is', without any express or implied
+--  warranty. In no event will the authors be held liable for any damages
+--  arising from the use of this software.
+--
+--  Permission is granted to anyone to use this software for any purpose,
+--  including commercial applications, and to alter it and redistribute it
+--  freely, subject to the following restrictions:
+--
+--     1. The origin of this software must not be misrepresented; you must not
+--     claim that you wrote the original software. If you use this software
+--     in a product, an acknowledgment in the product documentation would be
+--     appreciated but is not required.
+--
+--     2. Altered source versions must be plainly marked as such, and must not be
+--     misrepresented as being the original software.
+--
+--     3. This notice may not be removed or altered from any source
+--     distribution.
+--------------------------------------------------------------------------------------------------------------------
+--  SDL.Audio.Devices
+--
+--  Operating system audio device access and control.
+--------------------------------------------------------------------------------------------------------------------
+with Ada.Finalization;
+with SDL.Audio.Sample_Formats;
+with System;
+
+generic
+   type Frame_Type is private;
+   type Buffer_Index is (<>);
+   type Buffer_Type is array (Buffer_Index range <>) of Frame_Type;
+package SDL.Audio.Devices is
+
+   Audio_Device_Error : exception;
+
+   type Audio_Status is (Stopped, Playing, Paused) with Convention => C;
+
+   type Changes is mod 2 ** 32 with
+     Convention => C,
+     Size       => C.int'Size;
+
+   None      : constant Changes := 16#0000_0000#;
+   Frequency : constant Changes := 16#0000_0001#;
+   Format    : constant Changes := 16#0000_0002#;
+   Channels  : constant Changes := 16#0000_0004#;
+   Samples   : constant Changes := 16#0000_0008#;
+   Any       : constant Changes := Frequency or Format or Channels or Samples;
+
+   --  Allow users to derive new types from this.
+   type User_Data is tagged private;
+
+   type User_Data_Access is access all User_Data'Class;
+   pragma No_Strict_Aliasing (User_Data_Access);
+
+   --
+   --  The calculated values in this structure are calculated by SDL_OpenAudio().
+   --
+   --  For multi-channel audio, the default SDL channel mapping is:
+   --  2:  FL FR                       (stereo)
+   --  3:  FL FR LFE                   (2.1 surround)
+   --  4:  FL FR BL BR                 (quad)
+   --  5:  FL FR FC BL BR              (quad + center)
+   --  6:  FL FR FC LFE SL SR          (5.1 surround - last two can also be BL BR)
+   --  7:  FL FR FC LFE BC SL SR       (6.1 surround)
+   --  8:  FL FR FC LFE BL BR SL SR    (7.1 surround)
+   --
+   subtype Channel_Counts is Interfaces.Unsigned_8 with
+     Static_Predicate => Channel_Counts in 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8;
+
+   type Device is new Ada.Finalization.Limited_Controlled with private;
+
+   type Audio_Callback is access procedure
+     (User : in User_Data_Access;
+      Data : out Buffer_Type);
+
+   type Spec_Mode is (Desired, Obtained);
+
+   type Spec (Mode : Spec_Mode) is record
+      Frequency : C.int;
+      Format    : SDL.Audio.Sample_Formats.Sample_Format;
+      Channels  : Channel_Counts;
+      Samples   : Interfaces.Unsigned_16;
+      case Mode is
+         when Desired =>
+            null;
+         when Obtained =>
+            Silence : Interfaces.Unsigned_8;
+            Size    : Interfaces.Unsigned_32;
+      end case;
+   end record;
+
+   subtype Desired_Spec is Spec (Desired);
+   subtype Obtained_Spec is Spec (Obtained);
+
+   type ID is mod 2 ** 32 with
+     Convention => C;
+
+   function Total_Devices (Is_Capture : in Boolean := False) return Positive;
+
+   function Get_Name
+     (Index      : in Positive;
+      Is_Capture : in Boolean := False)
+      return String;
+
+   function Open
+     (Name            : in String := "";
+      Is_Capture      : in Boolean := False;
+      Desired         : in Desired_Spec;
+      Obtained        : out Obtained_Spec;
+      Callback        : in Audio_Callback := null;
+      User_Data       : in User_Data_Access := null;
+      Allowed_Changes : in Changes := None)
+      return Device;
+
+   procedure Open
+     (Self            : out Device;
+      Name            : in String := "";
+      Is_Capture      : in Boolean := False;
+      Desired         : in Desired_Spec;
+      Obtained        : out Obtained_Spec;
+      Callback        : in Audio_Callback := null;
+      User_Data       : in User_Data_Access := null;
+      Allowed_Changes : in Changes := None);
+
+   procedure Queue
+     (Self : in Device;
+      Data : aliased in Buffer_Type);
+
+   function Get_Status (Self : in Device) return Audio_Status;
+
+   function Get_ID (Self : in Device) return ID;
+
+   procedure Pause (Self : in Device; Pause : in Boolean);
+
+   function Get_Queued_Size (Self : in Device) return Interfaces.Unsigned_32;
+
+   procedure Clear_Queued (Self : in Device);
+
+   procedure Close (Self : in out Device);
+
+private
+
+   Default_Device : constant C.int := 1;
+
+   type User_Data is new Ada.Finalization.Controlled with null record;
+
+   type External_Data is record
+      Callback  : Audio_Callback;
+      User_Data : User_Data_Access;
+   end record;
+
+   type External_Data_Ptr is access all External_Data;
+
+   type Internal_Callback_Type is access procedure
+     (User        : in External_Data_Ptr;
+      Data        : in System.Address;
+      Byte_Length : in Positive)
+     with Convention => C;
+
+   procedure Internal_Callback
+     (External    : in External_Data_Ptr;
+      Data        : in System.Address;
+      Byte_Length : in Positive)
+     with Convention => C;
+
+   type Internal_Spec is record
+      Frequency : C.int;
+      Format    : SDL.Audio.Sample_Formats.Sample_Format;
+      Channels  : Channel_Counts;
+      Silence   : Interfaces.Unsigned_8;
+      Samples   : Interfaces.Unsigned_16;
+      Padding   : Interfaces.Unsigned_16;
+      Size      : Interfaces.Unsigned_32;
+      Callback  : Internal_Callback_Type;
+      User_Data : External_Data_Ptr;
+   end record with
+     Convention => C;
+
+   type Internal_Spec_Ptr is access all Internal_Spec with
+     Convention => C;
+
+   procedure Internal_Open
+     (Self      : out Device;
+      Num       : in C.int;
+      Callback  : in Audio_Callback;
+      User_Data : in User_Data_Access);
+
+   function To_Internal_Spec
+     (From     : in Desired_Spec;
+      Callback : in Audio_Callback;
+      External : in External_Data_Ptr)
+      return Internal_Spec;
+
+   function To_External_Spec (From : Internal_Spec) return Obtained_Spec;
+
+   type Device is new Ada.Finalization.Limited_Controlled with
+      record
+         Internal : ID := 0;
+         Is_Open  : Boolean := False;
+         External : aliased External_Data;
+      end record;
+
+   overriding
+   procedure Finalize (Self : in out Device);
+
+end SDL.Audio.Devices;

--- a/src/sdl-audio-sample_formats.ads
+++ b/src/sdl-audio-sample_formats.ads
@@ -1,0 +1,162 @@
+--------------------------------------------------------------------------------------------------------------------
+--  Copyright (c) 2021, Eduard Llamosí
+--
+--  This software is provided 'as-is', without any express or implied
+--  warranty. In no event will the authors be held liable for any damages
+--  arising from the use of this software.
+--
+--  Permission is granted to anyone to use this software for any purpose,
+--  including commercial applications, and to alter it and redistribute it
+--  freely, subject to the following restrictions:
+--
+--     1. The origin of this software must not be misrepresented; you must not
+--     claim that you wrote the original software. If you use this software
+--     in a product, an acknowledgment in the product documentation would be
+--     appreciated but is not required.
+--
+--     2. Altered source versions must be plainly marked as such, and must not be
+--     misrepresented as being the original software.
+--
+--     3. This notice may not be removed or altered from any source
+--     distribution.
+--------------------------------------------------------------------------------------------------------------------
+--  SDL.Audio.Frame_Formats
+--
+--  Access to audio sample data.
+--------------------------------------------------------------------------------------------------------------------
+with System; use System;
+
+package SDL.Audio.Sample_Formats is
+
+   type Sample_Bit_Size is mod 2 ** 8 with
+     Convention => C;
+
+   type Sample_Endianness is (Little_Endian, Big_Endian) with
+     Convention => C;
+
+   System_Endianness : constant Sample_Endianness :=
+     (if System.Default_Bit_Order = System.High_Order_First
+      then Big_Endian
+      else Little_Endian);
+
+   type Sample_Format is record
+      Bit_Size   : Sample_Bit_Size;
+      Float      : Boolean;
+      Endianness : Sample_Endianness := Little_Endian;
+      Signed     : Boolean;
+   end record with
+     Convention => C,
+     Size       => 16;
+   for Sample_Format use record
+      Bit_Size   at 0 range 0 .. 7;
+      Float      at 1 range 0 .. 0;
+      Endianness at 1 range 4 .. 4;
+      Signed     at 1 range 7 .. 7;
+   end record;
+
+   --
+   --  Audio format flags
+   --
+   --  Defaults to LSB byte order.
+   --
+
+   --  Unsigned 8-bit samples
+   Sample_Format_U8 : constant Sample_Format :=
+     (Bit_Size   => 8,
+      Float      => False,
+      Endianness => Little_Endian,
+      Signed     => False);
+   --  Signed 8-bit samples
+   Sample_Format_S8 : constant Sample_Format :=
+     (Bit_Size   => 8,
+      Float      => False,
+      Endianness => Little_Endian,
+      Signed     => True);
+   --  Unsigned 16-bit samples
+   Sample_Format_U16LSB : constant Sample_Format :=
+     (Bit_Size   => 16,
+      Float      => False,
+      Endianness => Little_Endian,
+      Signed     => False);
+   --  Signed 16-bit samples
+   Sample_Format_S16LSB : constant Sample_Format :=
+     (Bit_Size   => 16,
+      Float      => False,
+      Endianness => Little_Endian,
+      Signed     => True);
+   --  As above, but big-endian byte order
+   Sample_Format_U16MSB : constant Sample_Format :=
+     (Bit_Size   => 16,
+      Float      => False,
+      Endianness => Big_Endian,
+      Signed     => False);
+   --  As above, but big-endian byte order
+   Sample_Format_S16MSB : constant Sample_Format :=
+     (Bit_Size   => 16,
+      Float      => False,
+      Endianness => Big_Endian,
+      Signed     => True);
+   Sample_Format_U16 : constant Sample_Format := Sample_Format_U16LSB;
+   Sample_Format_S16 : constant Sample_Format := Sample_Format_S16LSB;
+
+   --
+   --  int32 support
+   --
+
+   --  32-bit integer samples
+   Sample_Format_S32LSB : constant Sample_Format :=
+     (Bit_Size   => 32,
+      Float      => False,
+      Endianness => Little_Endian,
+      Signed     => False);
+   --  As above, but big-endian byte order
+   Sample_Format_S32MSB : constant Sample_Format :=
+     (Bit_Size   => 32,
+      Float      => False,
+      Endianness => Big_Endian,
+      Signed     => True);
+   Sample_Format_S32 : constant Sample_Format := Sample_Format_S32LSB;
+
+   --
+   --  float32 support
+   --
+
+   --  32-bit floating point samples
+   Sample_Format_F32LSB : constant Sample_Format :=
+     (Bit_Size   => 32,
+      Float      => True,
+      Endianness => Little_Endian,
+      Signed     => True);
+   --  As above, but big-endian byte order
+   Sample_Format_F32MSB : constant Sample_Format :=
+     (Bit_Size   => 32,
+      Float      => True,
+      Endianness => Big_Endian,
+      Signed     => True);
+
+   --
+   --  Native audio byte ordering
+   --
+
+   Sample_Format_U16SYS : constant Sample_Format :=
+     (Bit_Size   => 16,
+      Float      => False,
+      Endianness => System_Endianness,
+      Signed     => False);
+   Sample_Format_S16SYS : constant Sample_Format :=
+     (Bit_Size   => 16,
+      Float      => False,
+      Endianness => System_Endianness,
+      Signed     => True);
+   Sample_Format_U32SYS : constant Sample_Format :=
+     (Bit_Size   => 32,
+      Float      => False,
+      Endianness => System_Endianness,
+      Signed     => False);
+   Sample_Format_S32SYS : constant Sample_Format :=
+     (Bit_Size   => 32,
+      Float      => False,
+      Endianness => System_Endianness,
+      Signed     => True);
+
+end SDL.Audio.Sample_Formats;

--- a/src/sdl-audio.adb
+++ b/src/sdl-audio.adb
@@ -1,0 +1,94 @@
+--------------------------------------------------------------------------------------------------------------------
+--  Copyright (c) 2021, Eduard Llamosí
+--
+--  This software is provided 'as-is', without any express or implied
+--  warranty. In no event will the authors be held liable for any damages
+--  arising from the use of this software.
+--
+--  Permission is granted to anyone to use this software for any purpose,
+--  including commercial applications, and to alter it and redistribute it
+--  freely, subject to the following restrictions:
+--
+--     1. The origin of this software must not be misrepresented; you must not
+--     claim that you wrote the original software. If you use this software
+--     in a product, an acknowledgment in the product documentation would be
+--     appreciated but is not required.
+--
+--     2. Altered source versions must be plainly marked as such, and must not be
+--     misrepresented as being the original software.
+--
+--     3. This notice may not be removed or altered from any source
+--     distribution.
+--------------------------------------------------------------------------------------------------------------------
+
+with Interfaces.C.Strings;
+with SDL.Error;
+
+package body SDL.Audio is
+
+   function Initialise (Name : in String := "") return Boolean is
+      function SDL_Audio_Init (C_Name : in C.Strings.chars_ptr) return C.int with
+        Import        => True,
+        Convention    => C,
+        External_Name => "SDL_AudioInit";
+
+      C_Str  : C.Strings.chars_ptr := C.Strings.Null_Ptr;
+      Result : C.int;
+   begin
+      if Name /= "" then
+         C_Str := C.Strings.New_String (Name);
+
+         Result := SDL_Audio_Init (C_Name => C_Str);
+
+         C.Strings.Free (C_Str);
+      else
+         Result := SDL_Audio_Init (C_Name => C.Strings.Null_Ptr);
+      end if;
+
+      return (Result = Success);
+   end Initialise;
+
+   function Total_Drivers return Positive is
+      function SDL_Get_Num_Audio_Drivers return C.int with
+        Import        => True,
+        Convention    => C,
+        External_Name => "SDL_GetNumAudioDrivers";
+
+      Num : constant C.int := SDL_Get_Num_Audio_Drivers;
+   begin
+      if Num < 0 then
+         raise Audio_Error with SDL.Error.Get;
+      end if;
+
+      return Positive (Num);
+   end Total_Drivers;
+
+   function Driver_Name (Index : in Positive) return String is
+      function SDL_Get_Audio_Driver (I : in C.int) return C.Strings.chars_ptr with
+        Import        => True,
+        Convention    => C,
+        External_Name => "SDL_GetAudioDriver";
+
+      --  Index is zero based, so need to subtract 1 to correct it.
+      C_Str : constant C.Strings.chars_ptr := SDL_Get_Audio_Driver (C.int (Index) - 1);
+   begin
+      return C.Strings.Value (C_Str);
+   end Driver_Name;
+
+   function Current_Driver_Name return String is
+      function SDL_Get_Current_Audio_Driver return C.Strings.chars_ptr with
+        Import        => True,
+        Convention    => C,
+        External_Name => "SDL_GetCurrentAudioDriver";
+
+      C_Str : constant C.Strings.chars_ptr := SDL_Get_Current_Audio_Driver;
+
+      use type C.Strings.chars_ptr;
+   begin
+      if C_Str = C.Strings.Null_Ptr then
+         raise Audio_Error with SDL.Error.Get;
+      end if;
+
+      return C.Strings.Value (C_Str);
+   end Current_Driver_Name;
+end SDL.Audio;

--- a/src/sdl-audio.ads
+++ b/src/sdl-audio.ads
@@ -1,0 +1,49 @@
+--------------------------------------------------------------------------------------------------------------------
+--  Copyright (c) 2021, Eduard Llamosí
+--
+--  This software is provided 'as-is', without any express or implied
+--  warranty. In no event will the authors be held liable for any damages
+--  arising from the use of this software.
+--
+--  Permission is granted to anyone to use this software for any purpose,
+--  including commercial applications, and to alter it and redistribute it
+--  freely, subject to the following restrictions:
+--
+--     1. The origin of this software must not be misrepresented; you must not
+--     claim that you wrote the original software. If you use this software
+--     in a product, an acknowledgment in the product documentation would be
+--     appreciated but is not required.
+--
+--     2. Altered source versions must be plainly marked as such, and must not be
+--     misrepresented as being the original software.
+--
+--     3. This notice may not be removed or altered from any source
+--     distribution.
+--------------------------------------------------------------------------------------------------------------------
+--  SDL.Audio
+--
+--  Common audio mixer and driver functionality.
+--------------------------------------------------------------------------------------------------------------------
+with Interfaces.C;
+
+package SDL.Audio is
+   pragma Preelaborate;
+
+   package C renames Interfaces.C;
+
+   Audio_Error : exception;
+
+   --  Audio drivers.
+   function Initialise (Name : in String := "") return Boolean;
+
+   procedure Finalise with
+     Import        => True,
+     Convention    => C,
+     External_Name => "SDL_AudioQuit";
+
+   function Total_Drivers return Positive;
+
+   function Driver_Name (Index : in Positive) return String;
+
+   function Current_Driver_Name return String;
+end SDL.Audio;

--- a/src/sdl.adb
+++ b/src/sdl.adb
@@ -58,4 +58,10 @@ package body SDL is
    begin
       return (SDL_Was_Initialised (Flags) = Flags);
    end Was_Initialised;
+
+   function To_Bool (Value : in Boolean) return SDL_Bool is
+   begin
+      return (if Value then SDL_True else SDL_False);
+   end To_Bool;
+
 end SDL;

--- a/src/sdl.ads
+++ b/src/sdl.ads
@@ -125,6 +125,8 @@ private
    type SDL_Bool is (SDL_False, SDL_True) with
      Convention => C;
 
+   function To_Bool (Value : in Boolean) return SDL_Bool;
+
    --  The next value is used in mapping the Ada types onto the C types, it is the word size used for all data
    --  in SDL, i.e. all data is 4 byte aligned so it works with 32-bit architectures.
    Word      : constant := 4;

--- a/test/audio.adb
+++ b/test/audio.adb
@@ -1,0 +1,127 @@
+with SDL;
+with SDL.Log;
+with SDL.Audio;
+with Audio_Support; use Audio_Support;
+
+procedure Audio is
+   Total_Drivers : Positive;
+   Total_Devices : Positive;
+   Success : Boolean;
+
+   Playback_Length : constant Duration := 2.0;
+
+   Desired  : Audio_Devices.Desired_Spec;
+   Obtained : Audio_Devices.Obtained_Spec;
+
+   State : aliased Audio_Support.Support_User_Data;
+begin
+   SDL.Log.Set (Category => SDL.Log.Application, Priority => SDL.Log.Debug);
+
+   Total_Drivers := SDL.Audio.Total_Drivers;
+   SDL.Log.Put_Debug ("Total Audio Drivers : " & Total_Drivers'Img);
+   for i in 1 .. Total_Drivers loop
+      SDL.Log.Put_Debug ("Driver" & i'Img & " : " & SDL.Audio.Driver_Name (i));
+   end loop;
+
+   Success := SDL.Initialise;
+   SDL.Log.Put_Debug ("SDL Init : " & Success'Img);
+
+   Total_Devices := Audio_Devices.Total_Devices (False);
+   SDL.Log.Put_Debug ("Total Audio Devices : " & Total_Devices'Img);
+   for i in 1 .. Total_Devices loop
+      SDL.Log.Put_Debug ("Device" & i'Img & " : " & Audio_Devices.Get_Name (i));
+   end loop;
+
+   Desired.Frequency := 48_000;
+   Desired.Format    := Audio_Support.Sample_Format;
+   Desired.Channels  := 2;
+   Desired.Samples   := 4_096;
+
+   SDL.Log.Put_Debug ("Desired - Frequency :" & Desired.Frequency'Img);
+   SDL.Log.Put_Debug ("Desired - Format/Bit_Size :" & Desired.Format.Bit_Size'Img);
+   SDL.Log.Put_Debug ("Desired - Format/Float :" & Desired.Format.Float'Img);
+   SDL.Log.Put_Debug ("Desired - Format/Big_Endian :" & Desired.Format.Endianness'Img);
+   SDL.Log.Put_Debug ("Desired - Format/Signed :" & Desired.Format.Signed'Img);
+   SDL.Log.Put_Debug ("Desired - Channels :" & Desired.Channels'Img);
+   SDL.Log.Put_Debug ("Desired - Samples :" & Desired.Samples'Img);
+
+   SDL.Log.Put_Debug ("Opening Default Device");
+
+   --  Use a callback to provide samples
+   declare
+      Device : constant Audio_Devices.Device :=
+        Audio_Devices.Open
+          (Desired   => Desired,
+           Obtained  => Obtained,
+           Callback  => Audio_Support.Callback'Access,
+           User_Data => State'Unchecked_Access);
+   begin
+      SDL.Log.Put_Debug ("Opened Device:" & Audio_Devices.Get_ID (Device)'Img);
+      SDL.Log.Put_Debug ("Device Status: " & Audio_Devices.Get_Status (Device)'Img);
+
+      SDL.Log.Put_Debug ("Obtained - Frequency :" & Obtained.Frequency'Img);
+      SDL.Log.Put_Debug ("Obtained - Format/Bit_Size :" & Obtained.Format.Bit_Size'Img);
+      SDL.Log.Put_Debug ("Obtained - Format/Float : " & Obtained.Format.Float'Img);
+      SDL.Log.Put_Debug ("Obtained - Format/Endianness : " & Obtained.Format.Endianness'Img);
+      SDL.Log.Put_Debug ("Obtained - Format/Signed : " & Obtained.Format.Signed'Img);
+      SDL.Log.Put_Debug ("Obtained - Channels :" & Obtained.Channels'Img);
+      SDL.Log.Put_Debug ("Obtained - Samples :" & Obtained.Samples'Img);
+      SDL.Log.Put_Debug ("Obtained - Silence :" & Obtained.Silence'Img);
+      SDL.Log.Put_Debug ("Obtained - Size :" & Obtained.Size'Img);
+
+      SDL.Log.Put_Debug ("Unpausing Device: " & Audio_Devices.Get_Status (Device)'Img);
+      Audio_Devices.Pause (Device, False);
+      SDL.Log.Put_Debug ("Device Status: " & Audio_Devices.Get_Status (Device)'Img);
+
+      delay Playback_Length;
+
+      SDL.Log.Put_Debug ("Implicitly Closing Device...");
+   end;
+
+   SDL.Log.Put_Debug ("Device Closed, silence expected.");
+
+   delay 1.0;
+
+   --  Use a queue to provide samples
+   declare
+      Device : constant Audio_Devices.Device :=
+        Audio_Devices.Open
+          (Desired  => Desired,
+           Obtained => Obtained);
+      Buffer : aliased Audio_Support.Buffer_Type := (1 .. 4_096 => (0, 0));
+      Segment_Count : constant := 40;
+   begin
+      SDL.Log.Put_Debug ("Opened Device: " & Audio_Devices.Get_ID (Device)'Img);
+      SDL.Log.Put_Debug ("Device Status: " & Audio_Devices.Get_Status (Device)'Img);
+
+      SDL.Log.Put_Debug ("Obtained - Frequency :" & Obtained.Frequency'Img);
+      SDL.Log.Put_Debug ("Obtained - Format/Bit_Size :" & Obtained.Format.Bit_Size'Img);
+      SDL.Log.Put_Debug ("Obtained - Format/Float : " & Obtained.Format.Float'Img);
+      SDL.Log.Put_Debug ("Obtained - Format/Endianness : " & Obtained.Format.Endianness'Img);
+      SDL.Log.Put_Debug ("Obtained - Format/Signed :" & Obtained.Format.Signed'Img);
+      SDL.Log.Put_Debug ("Obtained - Channels :" & Obtained.Channels'Img);
+      SDL.Log.Put_Debug ("Obtained - Samples :" & Obtained.Samples'Img);
+      SDL.Log.Put_Debug ("Obtained - Silence :" & Obtained.Silence'Img);
+      SDL.Log.Put_Debug ("Obtained - Size :" & Obtained.Size'Img);
+
+      SDL.Log.Put_Debug ("Unpausing Device: " & Audio_Devices.Get_Status (Device)'Img);
+      Audio_Devices.Pause (Device, False);
+      SDL.Log.Put_Debug ("Device Status: " & Audio_Devices.Get_Status (Device)'Img);
+
+      for i in 1 .. Segment_Count loop
+         Audio_Support.Callback (State'Unchecked_Access, Buffer);
+         Audio_Devices.Queue (Device, Buffer);
+         delay Playback_Length / Duration (Segment_Count);
+      end loop;
+
+      SDL.Log.Put_Debug ("Implicitly Closing Device...");
+   end;
+
+   SDL.Log.Put_Debug ("Device Closed, silence expected.");
+
+   delay 1.0;
+
+   SDL.Log.Put_Debug ("Program Finished.");
+
+   SDL.Finalise;
+end Audio;

--- a/test/audio_support.adb
+++ b/test/audio_support.adb
@@ -1,0 +1,21 @@
+with Ada.Unchecked_Conversion;
+
+package body Audio_Support is
+
+   procedure Callback
+     (User   : in Audio_Devices.User_Data_Access;
+      Buffer : out Buffer_Type)
+   is
+      UD : constant Support_User_Data_Access := Support_User_Data_Access (User);
+   begin
+      for BI in Buffer'Range loop
+         Buffer (BI) := Pulse_Frames (UD.State);
+         UD.Frame_Count := UD.Frame_Count + 1;
+         if UD.Frame_Count = 100 then
+            UD.State := (if UD.State = High then Low else High);
+            UD.Frame_Count := 0;
+         end if;
+      end loop;
+   end Callback;
+
+end Audio_Support;

--- a/test/audio_support.ads
+++ b/test/audio_support.ads
@@ -1,0 +1,47 @@
+with SDL.Audio.Devices;
+with SDL.Audio.Sample_Formats;
+with Interfaces;
+
+package Audio_Support is
+
+   subtype Sample is Interfaces.Integer_16;
+
+   type Frames is record
+      L, R : Sample;
+   end record with
+     Convention => C;
+
+   subtype Buffer_Index is Positive range Positive'Range;
+
+   type Buffer_Type is array (Buffer_Index range <>) of Frames;
+
+   package Audio_Devices is new SDL.Audio.Devices
+     (Frame_Type   => Frames,
+      Buffer_Index => Buffer_Index,
+      Buffer_Type  => Buffer_Type);
+
+   Sample_Format : constant SDL.Audio.Sample_Formats.Sample_Format :=
+     SDL.Audio.Sample_Formats.Sample_Format_S16SYS;
+
+   type Support_User_Data is new Audio_Devices.User_Data with private;
+
+   procedure Callback
+     (User   : in Audio_Devices.User_Data_Access;
+      Buffer : out Buffer_Type);
+
+private
+
+   type Pulse_State is (Low, High);
+
+   Pulse_Frames : constant array (Pulse_State) of Frames :=
+     (Low  => (Sample'First, Sample'First),
+      High => (Sample'Last,  Sample'Last));
+
+   type Support_User_Data is new Audio_Devices.User_Data with record
+      Frame_Count : Natural := 0;
+      State       : Pulse_State := Low;
+   end record;
+
+   type Support_User_Data_Access is access all Support_User_Data;
+
+end Audio_Support;


### PR DESCRIPTION
Another attempt to kick off: https://github.com/Lucretia/sdlada/issues/26

Thick binding to the methods required to output audio using either callbacks or queues. The reason I went for a thick binding is to hide the low level buffer passing/size calculations that is done with the C arrays so we can offer something more Ada-like through unconstrained arrays.

This implements:
- SDL_AudioInit
- SDL_GetAudioDeviceName
- SDL_GetAudioDeviceStatus
- SDL_GetAudioDriver
- SDL_CloseAudioDevice
- SDL_GetCurrentAudioDriver
- SDL_GetNumAudioDevices
- SDL_GetNumAudioDrivers
- SDL_GetQueuedAudioSize
- SDL_OpenAudioDevice
- SDL_PauseAudioDevice

This purposely skips the legacy `OpenAudio` (no Device) methods, as implementing the binding in a similar fashion would just result in duplicate signatures.

Also made a few tweaks so things compile out of the box on a recent MacOS version (Catalina) with SDL installed from Homebrew as well as renaming the os to account for future MacOS releases (no longer OSX). Also makes building the tests from GPR/GPS possible by adding the Linker flags in the project file.

**Possible Concerns**
- Copyright notices (not quite sure what's expected here, happy to remove myself from them if necessary)
- ~Dirty commit history. Can either squash this or separate the build config changes from audio additions into different PR~
- The `Device` abstraction might be thicker than needed, but I think that it works well and the overhead is minimal. Makes for a clean interface that can be easily changed under the hood without breaking the clients.
- The whole Audio Devices package is generic even though there are a few methods that don't really rely on that. I don't think it's worth dividing things as one is likely bound to use the bits that depend on the generic arguments in real world uses. 