### PR TITLE
Accessing Surface pixel data and creating Surface from pixel arrays

### DIFF
--- a/build/gnat/tests.gpr
+++ b/build/gnat/tests.gpr
@@ -6,7 +6,7 @@ project Tests is
    for Exec_Dir    use "gen/" & SDLAda.Mode & "/test";
    for Main        use ("test.adb", "version.adb", "platform.adb", "error.adb", "libraries.adb", "clipboard.adb",
                         "stream.adb", "stream2.adb", "surface.adb", "rwops.adb", "timers.adb", "create_window.adb",
-                        "mouse.adb",
+                        "mouse.adb", "surface_direct_access.adb",
 
                         --  For SDL.Image.
                         "load_surface.adb",

--- a/src/sdl-video-surfaces-makers.adb
+++ b/src/sdl-video-surfaces-makers.adb
@@ -58,8 +58,8 @@ package body SDL.Video.Surfaces.Makers is
                           BPP        : in Pixel_Depths := Element'Size;
                           Pitch      : in System.Storage_Elements.Storage_Offset;
                           Red_Mask   : in Colour_Masks;
-                          Blue_Mask  : in Colour_Masks;
                           Green_Mask : in Colour_Masks;
+                          Blue_Mask  : in Colour_Masks;
                           Alpha_Mask : in Colour_Masks) is
       type Element_Pointer_C is access all Element with Convention => C;
       function SDL_Create_RGB_Surface_From
@@ -87,6 +87,41 @@ package body SDL.Video.Surfaces.Makers is
                                                     Alpha_Mask => Alpha_Mask);
    end Create_From;
 
+   procedure Create_From_Array (Self       : in out Surface;
+                                Pixels     : access Element_Array;
+                                Red_Mask   : in Colour_Masks;
+                                Green_Mask : in Colour_Masks;
+                                Blue_Mask  : in Colour_Masks;
+                                Alpha_Mask : in Colour_Masks) is
+      type Element_Pointer_C is access all Element with Convention => C;
+      function SDL_Create_RGB_Surface_From
+        (Pixels     : in Element_Pointer_C;
+         Width      : in C.int           := 0;
+         Height     : in C.int           := 0;
+         Depth      : in Pixel_Depths    := 1;
+         Pitch      : in C.int           := 0;
+         Red_Mask   : in Colour_Masks    := 0;
+         Green_Mask : in Colour_Masks    := 0;
+         Blue_Mask  : in Colour_Masks    := 0;
+         Alpha_Mask : in Colour_Masks    := 0) return Internal_Surface_Pointer with
+        Import        => True,
+        Convention    => C,
+        External_Name => "SDL_CreateRGBSurfaceFrom";
+      use System.Storage_Elements;
+      Pitch : constant Storage_Offset := Pixels (Index'Succ (Pixels'First (1)), Pixels'First (2))'Address
+                                       - Pixels (Pixels'First (1), Pixels'First (2))'Address;
+   begin
+      Self.Internal := SDL_Create_RGB_Surface_From (
+         Pixels     => Pixels (Pixels'First (1), Pixels'First (2))'Access,
+         Width      => Pixels'Length (2),
+         Height     => Pixels'Length (1),
+         Depth      => Element'Size,
+         Pitch      => C.int (Pitch),
+         Red_Mask   => Red_Mask,
+         Green_Mask => Green_Mask,
+         Blue_Mask  => Blue_Mask,
+         Alpha_Mask => Alpha_Mask);
+   end Create_From_Array;
 
    --  TODO: SDL_CreateRGBSurfaceFrom
 

--- a/src/sdl-video-surfaces-makers.adb
+++ b/src/sdl-video-surfaces-makers.adb
@@ -122,6 +122,8 @@ package body SDL.Video.Surfaces.Makers is
          Blue_Mask  => Blue_Mask,
          Alpha_Mask => Alpha_Mask);
    end Create_From_Array;
+   -- Note: Create_From_Array cannot get packed (1- and 4-bit) array types.
+   -- Also there may be issue with 24-bit pixels (does SDL imply 4-byte alignment in this case?)
 
    --  TODO: SDL_CreateRGBSurfaceFrom
 

--- a/src/sdl-video-surfaces-makers.adb
+++ b/src/sdl-video-surfaces-makers.adb
@@ -122,8 +122,6 @@ package body SDL.Video.Surfaces.Makers is
          Blue_Mask  => Blue_Mask,
          Alpha_Mask => Alpha_Mask);
    end Create_From_Array;
-   -- Note: Create_From_Array cannot get packed (1- and 4-bit) array types.
-   -- Also there may be issue with 24-bit pixels (does SDL imply 4-byte alignment in this case?)
 
    --  TODO: SDL_CreateRGBSurfaceFrom
 

--- a/src/sdl-video-surfaces-makers.adb
+++ b/src/sdl-video-surfaces-makers.adb
@@ -21,6 +21,7 @@
 --     distribution.
 --------------------------------------------------------------------------------------------------------------------
 with Ada.Finalization;
+
 package body SDL.Video.Surfaces.Makers is
    procedure Create (Self       : in out Surface;
                      Size       : in SDL.Sizes;
@@ -50,6 +51,42 @@ package body SDL.Video.Surfaces.Makers is
                                                Blue_Mask  => Blue_Mask,
                                                Alpha_Mask => Alpha_Mask);
    end Create;
+
+   procedure Create_From (Self       : in out Surface;
+                          Pixels     : in Element_Pointer;
+                          Size       : in SDL.Sizes;
+                          BPP        : in Pixel_Depths := Element'Size;
+                          Pitch      : in System.Storage_Elements.Storage_Offset;
+                          Red_Mask   : in Colour_Masks;
+                          Blue_Mask  : in Colour_Masks;
+                          Green_Mask : in Colour_Masks;
+                          Alpha_Mask : in Colour_Masks) is
+      type Element_Pointer_C is access all Element with Convention => C;
+      function SDL_Create_RGB_Surface_From
+        (Pixels     : in Element_Pointer_C;
+         Width      : in C.int           := 0;
+         Height     : in C.int           := 0;
+         Depth      : in Pixel_Depths    := 1;
+         Pitch      : in C.int           := 0;
+         Red_Mask   : in Colour_Masks    := 0;
+         Green_Mask : in Colour_Masks    := 0;
+         Blue_Mask  : in Colour_Masks    := 0;
+         Alpha_Mask : in Colour_Masks    := 0) return Internal_Surface_Pointer with
+        Import        => True,
+        Convention    => C,
+        External_Name => "SDL_CreateRGBSurfaceFrom";
+   begin
+      Self.Internal := SDL_Create_RGB_Surface_From (Pixels     => Element_Pointer_C (Pixels),
+                                                    Width      => Size.Width,
+                                                    Height     => Size.Height,
+                                                    Depth      => BPP,
+                                                    Pitch      => C.int (Pitch),
+                                                    Red_Mask   => Red_Mask,
+                                                    Green_Mask => Green_Mask,
+                                                    Blue_Mask  => Blue_Mask,
+                                                    Alpha_Mask => Alpha_Mask);
+   end Create_From;
+
 
    --  TODO: SDL_CreateRGBSurfaceFrom
 

--- a/src/sdl-video-surfaces-makers.adb
+++ b/src/sdl-video-surfaces-makers.adb
@@ -21,6 +21,7 @@
 --     distribution.
 --------------------------------------------------------------------------------------------------------------------
 with Ada.Finalization;
+with System.Address_To_Access_Conversions;
 
 package body SDL.Video.Surfaces.Makers is
    procedure Create (Self       : in out Surface;
@@ -94,8 +95,9 @@ package body SDL.Video.Surfaces.Makers is
                                 Blue_Mask  : in Colour_Masks;
                                 Alpha_Mask : in Colour_Masks) is
       type Element_Pointer_C is access all Element with Convention => C;
+      package Convert is new System.Address_To_Access_Conversions (Element);
       function SDL_Create_RGB_Surface_From
-        (Pixels     : in Element_Pointer_C;
+        (Pixels     : in Element_Pointer_C; -- Note: using System.Address here is not portable
          Width      : in C.int           := 0;
          Height     : in C.int           := 0;
          Depth      : in Pixel_Depths    := 1;
@@ -112,7 +114,7 @@ package body SDL.Video.Surfaces.Makers is
                                        - Pixels (Pixels'First (1), Pixels'First (2))'Address;
    begin
       Self.Internal := SDL_Create_RGB_Surface_From (
-         Pixels     => Pixels (Pixels'First (1), Pixels'First (2))'Access,
+         Pixels     => Element_Pointer_C (Convert.To_Pointer (Pixels (Pixels'First (1), Pixels'First (2))'Address)),
          Width      => Pixels'Length (2),
          Height     => Pixels'Length (1),
          Depth      => Element'Size,

--- a/src/sdl-video-surfaces-makers.ads
+++ b/src/sdl-video-surfaces-makers.ads
@@ -46,9 +46,21 @@ package SDL.Video.Surfaces.Makers is
                           BPP        : in Pixel_Depths := Element'Size;
                           Pitch      : in System.Storage_Elements.Storage_Offset;
                           Red_Mask   : in Colour_Masks;
-                          Blue_Mask  : in Colour_Masks;
                           Green_Mask : in Colour_Masks;
+                          Blue_Mask  : in Colour_Masks;
                           Alpha_Mask : in Colour_Masks);
+
+   generic
+      type Element is private;
+      type Index is (<>);
+      type Element_Array is array (Index range <>, Index range <>) of aliased Element;
+   procedure Create_From_Array (Self       : in out Surface;
+                                Pixels     : access Element_Array;
+                                Red_Mask   : in Colour_Masks;
+                                Green_Mask : in Colour_Masks;
+                                Blue_Mask  : in Colour_Masks;
+                                Alpha_Mask : in Colour_Masks);
+
 
    --  TODO: This is likely a temporary place for this. It's likely I will add a Streams package.
    --     procedure Create (Self : in out Surface; File_Name : in String);

--- a/src/sdl-video-surfaces-makers.ads
+++ b/src/sdl-video-surfaces-makers.ads
@@ -60,7 +60,8 @@ package SDL.Video.Surfaces.Makers is
                                 Green_Mask : in Colour_Masks;
                                 Blue_Mask  : in Colour_Masks;
                                 Alpha_Mask : in Colour_Masks);
-
+   --  Note: Create_From_Array cannot get packed (1- and 4-bit) array types.
+   --  Also there may be issue with 24-bit pixels (does SDL imply 4-byte alignment in this case?)
 
    --  TODO: This is likely a temporary place for this. It's likely I will add a Streams package.
    --     procedure Create (Self : in out Surface; File_Name : in String);

--- a/src/sdl-video-surfaces-makers.ads
+++ b/src/sdl-video-surfaces-makers.ads
@@ -53,15 +53,17 @@ package SDL.Video.Surfaces.Makers is
    generic
       type Element is private;
       type Index is (<>);
-      type Element_Array is array (Index range <>, Index range <>) of aliased Element;
+      type Element_Array is array (Index range <>, Index range <>) of Element;
    procedure Create_From_Array (Self       : in out Surface;
                                 Pixels     : access Element_Array;
                                 Red_Mask   : in Colour_Masks;
                                 Green_Mask : in Colour_Masks;
                                 Blue_Mask  : in Colour_Masks;
                                 Alpha_Mask : in Colour_Masks);
-   --  Note: Create_From_Array cannot get packed (1- and 4-bit) array types.
-   --  Also there may be issue with 24-bit pixels (does SDL imply 4-byte alignment in this case?)
+   --  Note: I'm unsure what happen when packed (1- or -4bit) arrays are used here.
+   --        So, at least check that they have whole number of bytes per row
+   --        (E. g. even width in 4-bit)
+   --  Note: There may be issue with 24-bit pixels (does SDL imply 4-byte alignment in this case?)
 
    --  TODO: This is likely a temporary place for this. It's likely I will add a Streams package.
    --     procedure Create (Self : in out Surface; File_Name : in String);

--- a/src/sdl-video-surfaces-makers.ads
+++ b/src/sdl-video-surfaces-makers.ads
@@ -24,6 +24,8 @@
 --
 --  Functions to create surface objects.
 --------------------------------------------------------------------------------------------------------------------
+with System.Storage_Elements;
+
 package SDL.Video.Surfaces.Makers is
    pragma Preelaborate;
 
@@ -34,6 +36,19 @@ package SDL.Video.Surfaces.Makers is
                      Blue_Mask  : in Colour_Masks;
                      Green_Mask : in Colour_Masks;
                      Alpha_Mask : in Colour_Masks);
+
+   generic
+       type Element is private;
+       type Element_Pointer is access all Element;
+   procedure Create_From (Self       : in out Surface;
+                          Pixels     : in Element_Pointer;
+                          Size       : in SDL.Sizes;
+                          BPP        : in Pixel_Depths := Element'Size;
+                          Pitch      : in System.Storage_Elements.Storage_Offset;
+                          Red_Mask   : in Colour_Masks;
+                          Blue_Mask  : in Colour_Masks;
+                          Green_Mask : in Colour_Masks;
+                          Alpha_Mask : in Colour_Masks);
 
    --  TODO: This is likely a temporary place for this. It's likely I will add a Streams package.
    --     procedure Create (Self : in out Surface; File_Name : in String);

--- a/src/sdl-video-surfaces.adb
+++ b/src/sdl-video-surfaces.adb
@@ -35,6 +35,11 @@ package body SDL.Video.Surfaces is
       return SDL.Sizes'(Self.Internal.Width, Self.Internal.Height);
    end Size;
 
+   function Pitch (Self : in Surface) return C.int is
+   begin
+      return Self.Internal.Pitch;
+   end Pitch;
+
    function Pixels (Self : in Surface) return System.Address is
    begin
       if Must_Lock (Self) and then Self.Internal.Locked <= 0 then

--- a/src/sdl-video-surfaces.adb
+++ b/src/sdl-video-surfaces.adb
@@ -62,10 +62,6 @@ package body SDL.Video.Surfaces is
 
       function Get_Row (Self : in Surface; Y : in SDL.Coordinate) return Element_Pointer is
       begin
-         if Y not in 0 .. Self.Internal.Height - 1 then
-            raise Surface_Error with "Access outside of surface.";
-         end if;
-
          --  Two conversions required, because there's no legal
          --  direct conversion from System.Address and arbitrary Pointer.
          return Element_Pointer (Convert.To_Pointer (Self.Pixels

--- a/src/sdl-video-surfaces.adb
+++ b/src/sdl-video-surfaces.adb
@@ -67,7 +67,7 @@ package body SDL.Video.Surfaces is
          end if;
 
          --  Two conversions required, because there's no legal
-         --  direct conversion procedure from System.Address to Interfaces.C.Pointers.Pointer.
+         --  direct conversion from System.Address and arbitrary Pointer.
          return Element_Pointer (Convert.To_Pointer (Self.Pixels
            + Storage_Offset (Self.Internal.Pitch) * Storage_Offset (Y)));
       end Get_Row;

--- a/src/sdl-video-surfaces.ads
+++ b/src/sdl-video-surfaces.ads
@@ -83,7 +83,7 @@ package SDL.Video.Surfaces is
 
       --  Get the starting address of a specific pixel row.
       function Get_Row (Self : in Surface; Y : in SDL.Coordinate) return Element_Pointer with
-        Inline => True;
+        Inline => True, Pre => Y in 0 .. Self.Size.Height - 1;
    end Pixel_Data;
 
    generic

--- a/src/sdl-video-surfaces.ads
+++ b/src/sdl-video-surfaces.ads
@@ -70,7 +70,6 @@ package SDL.Video.Surfaces is
      Inline => True;
 
    --  Get the address of actual pixels
-   --  TODO: Make generic so that we can get access to specific arrays which are mapped onto the Pixels address.
    function Pixels (Self : in Surface) return System.Address with
      Inline => True;
 

--- a/src/sdl-video-surfaces.ads
+++ b/src/sdl-video-surfaces.ads
@@ -65,6 +65,11 @@ package SDL.Video.Surfaces is
    function Size (Self : in Surface) return SDL.Sizes with
      Inline => True;
 
+   --  Get the pitch parameter (number of bytes between lines)
+   function Pitch (Self : in Surface) return C.int with
+     Inline => True;
+
+   --  Get the address of actual pixels
    --  TODO: Make generic so that we can get access to specific arrays which are mapped onto the Pixels address.
    function Pixels (Self : in Surface) return System.Address with
      Inline => True;

--- a/src/sdl-video-surfaces.ads
+++ b/src/sdl-video-surfaces.ads
@@ -75,6 +75,19 @@ package SDL.Video.Surfaces is
      Inline => True;
 
    generic
+      type Element is private;
+      type Element_Pointer is access all Element;
+   package Pixel_Data is
+      --  Get the starting address of whole data.
+      function Get (Self : in Surface) return Element_Pointer with
+        Inline => True;
+
+      --  Get the starting address of a specific pixel row.
+      function Get_Row (Self : in Surface; Y : in SDL.Coordinate) return Element_Pointer with
+        Inline => True;
+   end Pixel_Data;
+
+   generic
       type Data is private;
       type Data_Pointer is access all Data;
    package User_Data is

--- a/test/surface_direct_access.adb
+++ b/test/surface_direct_access.adb
@@ -12,13 +12,12 @@ procedure Surface_Direct_Access is
    W : SDL.Video.Windows.Window;
    package Sprite is
       subtype Pixel is Interfaces.Unsigned_16;
-      type Pixel_Access is access all Pixel;
-      type Image_Type is array (0 .. 15, 0 .. 15) of aliased Pixel;
+      type Image_Type is array (Integer range <>, Integer range <>) of aliased Pixel;
 
       T : constant := 16#0000#;
       R : constant := 16#F00F#;
       W : constant := 16#FFFF#;
-      Image : Image_Type := (
+      Image : aliased Image_Type := (
          (T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T),
          (T, T, T, R, R, R, T, T, T, R, R, R, T, T, T, T),
          (T, T, R, W, W, R, R, T, R, W, W, R, R, T, T, T),
@@ -37,9 +36,10 @@ procedure Surface_Direct_Access is
          (T, T, T, T, T, T, T, R, T, T, T, T, T, T, T, T)
       );
       S : SDL.Video.Surfaces.Surface;
-      procedure Create_From is new SDL.Video.Surfaces.Makers.Create_From (
+      procedure Create_From is new SDL.Video.Surfaces.Makers.Create_From_Array (
          Element => Pixel,
-         Element_Pointer => Pixel_Access);
+         Index   => Integer,
+         Element_Array => Image_Type);
    end Sprite;
 begin
    SDL.Log.Set (Category => SDL.Log.Application, Priority => SDL.Log.Debug);
@@ -52,11 +52,7 @@ begin
                                        Flags    => SDL.Video.Windows.Resizable);
 
       Sprite.Create_From (Self       => Sprite.S,
-                          Pixels     => Sprite.Image (0, 0)'Access,
-                          Size       => (Width  => Sprite.Image'Length (2),
-                                         Height => Sprite.Image'Length (1)),
-                          BPP        => 16,
-                          Pitch      => 32, -- TODO: calculation
+                          Pixels     => Sprite.Image'Access,
                           Red_Mask   => 16#000F#,
                           Green_Mask => 16#00F0#,
                           Blue_Mask  => 16#0F00#,

--- a/test/surface_direct_access.adb
+++ b/test/surface_direct_access.adb
@@ -1,0 +1,112 @@
+with Interfaces.C.Pointers;
+with System.Storage_Elements;
+with System.Address_To_Access_Conversions;
+with SDL.Events.Events;
+with SDL.Events.Keyboards;
+with SDL.Log;
+with SDL.Video.Palettes;
+with SDL.Video.Pixel_Formats;
+with SDL.Video.Surfaces.Makers;
+with SDL.Video.Windows.Makers;
+
+procedure Surface_Direct_Access is
+   W : SDL.Video.Windows.Window;
+   use System.Storage_Elements;
+begin
+   SDL.Log.Set (Category => SDL.Log.Application, Priority => SDL.Log.Debug);
+
+   if SDL.Initialise (Flags => SDL.Enable_Screen) = True then
+      SDL.Video.Windows.Makers.Create (Win      => W,
+                                       Title    => "Surface direct access (Esc to exit)",
+                                       Position => SDL.Natural_Coordinates'(X => 100, Y => 100),
+                                       Size     => SDL.Positive_Sizes'(800, 640),
+                                       Flags    => SDL.Video.Windows.Resizable);
+
+      --  Main loop.
+      declare
+         Pixel_Depth      : constant := 16;
+         --  Not all Pixel_Depth values are displayed correctly.
+         --  Actual data layout may differ than implied here.
+         type Pixel      is mod 2**Pixel_Depth;
+         type Pixel_Array is array (Integer range <>) of aliased Pixel;
+         package Pixel_Pointers is new Interfaces.C.Pointers (Index              => Integer,
+                                                              Element            => Pixel,
+                                                              Element_Array      => Pixel_Array,
+                                                              Default_Terminator => 0);
+         use type Pixel_Pointers.Pointer;
+         package Convert is new System.Address_To_Access_Conversions (Object => Pixel);
+         S                : SDL.Video.Surfaces.Surface;
+         Pixels           : System.Address;
+         Pitch            : Interfaces.C.int;
+
+         --  This procedure writes individual pixel in the surface (no blending or masking)
+         procedure Write_Pixel (X, Y : Integer; Colour : Pixel) is
+            Row_Addr : constant System.Address          := Pixels + Storage_Offset (Pitch) * Storage_Offset (Y);
+            --  Get the starting address of a specific pixel row. Note that Pitch parameter is in
+            --  storage elements, not pixels, so computation could be done before the conversion to a typed pointer
+            Row_Ptr  : constant Pixel_Pointers.Pointer  := Pixel_Pointers.Pointer (Convert.To_Pointer (Row_Addr));
+            --  Convert to the pointer. Two conversions required, because there's
+            --  no direct conversion procedure from System.Address to Interfaces.C.Pointers.Pointer.
+            Ptr      : constant Pixel_Pointers.Pointer  := Row_Ptr + Interfaces.C.ptrdiff_t (X);
+         begin
+            Ptr.all := Colour;
+         end Write_Pixel;
+
+         Window_Surface   : SDL.Video.Surfaces.Surface;
+         Event            : SDL.Events.Events.Events;
+         Finished         : Boolean := False;
+
+         use type SDL.Events.Keyboards.Key_Codes;
+      begin
+         SDL.Video.Surfaces.Makers.Create (Self => S,
+                                           Size => (800, 640),
+                                           BPP => Pixel_Depth,
+                                           Red_Mask => 0,
+                                           Blue_Mask => 0,
+                                           Green_Mask => 0,
+                                           Alpha_Mask => 0);  --  a surface with known pixel depth
+
+         S.Lock;
+
+         Pixels := S.Pixels;
+         Pitch := S.Pitch;
+
+         for X in 0 .. 799 loop
+            for Y in 0 .. 639 loop
+               Write_Pixel (X, Y, Pixel (SDL.Video.Pixel_Formats.To_Pixel
+                              (Format => S.Pixel_Format,
+                               Red    => SDL.Video.Palettes.Colour_Component (Y * 255 / 639),
+                               Green  => SDL.Video.Palettes.Colour_Component (X * 255 / 799),
+                               Blue   => SDL.Video.Palettes.Colour_Component (255 - (X + Y) * 255 / (799 + 639)))));
+            end loop;
+         end loop;
+         S.Unlock;
+
+         Window_Surface := W.Get_Surface;
+         Window_Surface.Blit (S);
+         W.Update_Surface;
+
+         loop
+            while SDL.Events.Events.Poll (Event) loop
+               case Event.Common.Event_Type is
+                  when SDL.Events.Quit =>
+                     Finished := True;
+
+                  when SDL.Events.Keyboards.Key_Down =>
+                     if Event.Keyboard.Key_Sym.Key_Code = SDL.Events.Keyboards.Code_Escape then
+                        Finished := True;
+                     end if;
+
+                  when others =>
+                     null;
+               end case;
+            end loop;
+
+            exit when Finished;
+         end loop;
+      end;
+
+      W.Finalize;
+      SDL.Finalise;
+   end if;
+end Surface_Direct_Access;

--- a/test/surface_direct_access.adb
+++ b/test/surface_direct_access.adb
@@ -1,12 +1,15 @@
 with Interfaces.C.Pointers;
 with SDL.Events.Events;
 with SDL.Events.Keyboards;
+with SDL.Events.Mice;
 with SDL.Log;
 with SDL.Video.Palettes;
 with SDL.Video.Pixel_Formats;
 with SDL.Video.Surfaces.Makers;
 with SDL.Video.Rectangles;
 with SDL.Video.Windows.Makers;
+with Ada.Numerics.Long_Complex_Types;
+use  Ada.Numerics.Long_Complex_Types;
 
 procedure Surface_Direct_Access is
    W : SDL.Video.Windows.Window;
@@ -46,9 +49,9 @@ begin
 
    if SDL.Initialise (Flags => SDL.Enable_Screen) = True then
       SDL.Video.Windows.Makers.Create (Win      => W,
-                                       Title    => "Surface direct access (Esc to exit)",
+                                       Title    => "Surface direct access: Julia set interactive view (Esc to exit)",
                                        Position => SDL.Natural_Coordinates'(X => 100, Y => 100),
-                                       Size     => SDL.Positive_Sizes'(800, 640),
+                                       Size     => SDL.Positive_Sizes'(640, 640),
                                        Flags    => SDL.Video.Windows.Resizable);
 
       Sprite.Create_From (Self       => Sprite.S,
@@ -83,6 +86,81 @@ begin
             Ptr.all := Colour;
          end Write_Pixel;
 
+         Cursor : SDL.Natural_Coordinates;
+
+         N_Max : constant := 63; --  Maximum number of iterations for Julia set
+
+         --  Precalculated map of colours
+         False_Colour : Pixel_Array (0 .. N_Max);
+
+         procedure Make_False_Colour is
+            Z : Complex;
+            A : constant Complex := Compose_From_Polar (1.0, 1.0, 3.0);
+            R, G, B : Integer;
+         begin
+            for I in 0 .. N_Max loop
+               case I is
+                  when 0 .. N_Max - 1 =>
+                     Z := Compose_From_Polar
+                          (127.0, Long_Float (I), Long_Float (N_Max));
+                     B := 127 + Integer (Re (Z));
+                     R := 127 + Integer (Re (Z * A));
+                     G := 127 + Integer (Re (Z * A * A));
+                  when others => -- last iteration means we did'nt reach condition
+                     R := 0;
+                     G := 0;
+                     B := 0;
+               end case;
+               False_Colour (I) := Pixel (SDL.Video.Pixel_Formats.To_Pixel
+                                 (Format => S.Pixel_Format,
+                                  Red    => SDL.Video.Palettes.Colour_Component (R),
+                                  Green  => SDL.Video.Palettes.Colour_Component (G),
+                                  Blue   => SDL.Video.Palettes.Colour_Component (B)));
+            end loop;
+         end Make_False_Colour;
+
+         procedure Render is
+            --  A constant for Julia set iteration
+            C : constant Complex := (
+                (Long_Float (Cursor.X) / 640.0) * 4.0 - 2.0,
+                (Long_Float (Cursor.Y) / 640.0) * 4.0 - 2.0);
+            --  Julia set iteration variable
+            Z : Complex;
+            --  Julia set iteration counter
+            N : Integer;
+         begin
+            S.Lock;
+            for X in 0 .. 639 loop
+               for Y in 0 .. 639 loop
+                  --  Julia set iteration
+                  Z := ((Long_Float (X) / 640.0) * 4.0 - 2.0,
+                        (Long_Float (Y) / 640.0) * 4.0 - 2.0);
+                  N := 0;
+                  --  Julia set iteration
+                  while Re (Z)**2 + Im (Z)**2 < 4.0 and N < N_Max loop
+                     N := N + 1;
+                     Z := Z**2 + C;
+                  end loop;
+
+                  Write_Pixel (X, Y, False_Colour (N));
+               end loop;
+            end loop;
+            S.Unlock;
+
+            declare
+               TR, SR : SDL.Video.Rectangles.Rectangle := (X => 0,
+                                                           Y => 0,
+                                                           Width  => Sprite.Image'Length (2),
+                                                           Height => Sprite.Image'Length (1));
+            begin
+               TR.X := 20;
+               TR.Y := 20;
+               S.Blit (TR,
+                       Sprite.S,
+                       SR);
+            end;
+         end Render;
+
          Window_Surface   : SDL.Video.Surfaces.Surface;
          Event            : SDL.Events.Events.Events;
          Finished         : Boolean := False;
@@ -90,38 +168,15 @@ begin
          use type SDL.Events.Keyboards.Key_Codes;
       begin
          SDL.Video.Surfaces.Makers.Create (Self => S,
-                                           Size => (800, 640),
+                                           Size => (640, 640),
                                            BPP => Pixel_Depth,
                                            Red_Mask => 0,
                                            Blue_Mask => 0,
                                            Green_Mask => 0,
                                            Alpha_Mask => 0);  --  a surface with known pixel depth
 
-         S.Lock;
-
-         for X in 0 .. 799 loop
-            for Y in 0 .. 639 loop
-               Write_Pixel (X, Y, Pixel (SDL.Video.Pixel_Formats.To_Pixel
-                              (Format => S.Pixel_Format,
-                               Red    => SDL.Video.Palettes.Colour_Component (Y * 255 / 639),
-                               Green  => SDL.Video.Palettes.Colour_Component (X * 255 / 799),
-                               Blue   => SDL.Video.Palettes.Colour_Component (255 - (X + Y) * 255 / (799 + 639)))));
-            end loop;
-         end loop;
-         S.Unlock;
-
-         declare
-            TR, SR : SDL.Video.Rectangles.Rectangle := (X => 0,
-                                                        Y => 0,
-                                                        Width  => Sprite.Image'Length (2),
-                                                        Height => Sprite.Image'Length (1));
-         begin
-            TR.X := 20;
-            TR.Y := 20;
-            S.Blit (TR,
-                    Sprite.S,
-                    SR);
-         end;
+         Make_False_Colour;
+         Render;
 
          Window_Surface := W.Get_Surface;
          Window_Surface.Blit (S);
@@ -137,6 +192,13 @@ begin
                      if Event.Keyboard.Key_Sym.Key_Code = SDL.Events.Keyboards.Code_Escape then
                         Finished := True;
                      end if;
+
+                  when SDL.Events.Mice.Motion =>
+                     Cursor := (X => Event.Mouse_Motion.X, Y => Event.Mouse_Motion.Y);
+                     Render;
+                     Window_Surface := W.Get_Surface;
+                     Window_Surface.Blit (S);
+                     W.Update_Surface;
 
                   when others =>
                      null;


### PR DESCRIPTION
Hello! Here's little contribution to the project to make direct pixel access available.
Added function to obtain Surface.Internals.Pitch.
Added generic function to get Pixels as an access type.
Added generic function to get specific row address (like an above but with some address arithmetic)
Made an example / test for software drawing.
UPD:
Added a fairly direct binding to `SDL_CreateRGBSurfaceFrom`
Added second binding taking Ada's 2d-array.

I didn't add function to get single pixel address, it
* not always possible (like in 1-bit and 4-bit pixels)
* in most cases is not optimal to recalculate address every pixel
* it require some investigation.