### PR TITLE
Support MacPorts, fix for Homebrew on aarch64

### DIFF
--- a/alire.toml
+++ b/alire.toml
@@ -13,7 +13,7 @@ tags = ["gamedev", "games", "portable", "cross-platform"]
 project-files = ["build/gnat/sdlada.gpr"] #, "build/gnat/"]
 
 [gpr-externals]
-  SDL_PLATFORM = ["linux", "bsd", "windows", "macosx", "macos_homebrew", "ios", "android"]
+  SDL_PLATFORM = ["linux", "bsd", "windows", "macosx", "macos_homebrew", "macos_ports", "ios", "android"]
   SDL_MODE = ["debug", "release"]
 
 # [gpr-set-externals]
@@ -22,7 +22,7 @@ project-files = ["build/gnat/sdlada.gpr"] #, "build/gnat/"]
 [gpr-set-externals.'case(os)']
   linux   = { SDL_PLATFORM = "linux" }
   windows = { SDL_PLATFORM = "windows" }
-  macos   = { SDL_PLATFORM = "macos_homebrew" }
+  # macos   = { SDL_PLATFORM = "macos_homebrew" }
 
 [[actions]]
   type = "pre-build"

--- a/build/gnat/sdlada.gpr
+++ b/build/gnat/sdlada.gpr
@@ -1,5 +1,5 @@
 library project SDLAda is
-   type Platform_Type is ("linux", "bsd", "windows", "macosx", "macos_homebrew", "ios", "android");
+   type Platform_Type is ("linux", "bsd", "windows", "macosx", "macos_homebrew", "macos_ports", "ios", "android");
    type Mode_Type is ("debug", "release");
 
    Platform : Platform_Type := external ("SDL_PLATFORM", "linux");
@@ -8,7 +8,7 @@ library project SDLAda is
    Source_Platform := "";
 
    case Platform is
-      when "macos_homebrew" =>
+      when "macos_homebrew" | "macos_ports" =>
          Source_Platform := "../../src/macosx";
 
       when others =>
@@ -49,7 +49,14 @@ library project SDLAda is
 
          when "macos_homebrew" =>
             C_Switches   := C_Switches & ("-DSDL_HOMEBREW",
-                                          "-I/usr/local/include",
+                                          "-I"
+                                          & external ("HOMEBREW_PREFIX")
+                                          & "/include",
+                                          "-D_REENTRANT");
+
+         when "macos_ports" =>
+            C_Switches   := C_Switches & ("-DSDL_MACPORTS",
+                                          "-I/opt/local/include",
                                           "-D_REENTRANT");
 
          when others =>

--- a/src/image/version_images.c
+++ b/src/image/version_images.c
@@ -21,7 +21,7 @@
  *    distribution.
  **********************************************************************************************************************/
 #ifdef __APPLE__
-    #ifdef SDL_HOMEBREW
+    #if defined(SDL_HOMEBREW) || defined(SDL_MACPORTS)
         #include <SDL2/SDL_image.h>
     #else
         #include <SDL2_image/SDL_image.h>

--- a/src/ttf/version_ttf.c
+++ b/src/ttf/version_ttf.c
@@ -21,7 +21,7 @@
  *    distribution.
  **********************************************************************************************************************/
 #ifdef __APPLE__
-    #ifdef SDL_HOMEBREW
+    #if defined(SDL_HOMEBREW) || defined(SDL_MACPORTS)
         #include <SDL2/SDL_ttf.h>
     #else
         #include <SDL2_ttf/SDL_ttf.h>


### PR DESCRIPTION
On my machine (M1 Mac mini), this runs on either Homebrew or MacPorts. The only problem is that we can't at the moment override the `gpr-set-externals`
```macos   = { SDL_PLATFORM = "macos_homebrew" }```
in `alire.toml`, so I've commented it out.

I'll completely understand if you're already working on this, or want to hold fire until we've found a solution to the above.
