### PR TITLE
Remove unused withs and fix/ignore other warnings.

### DIFF
--- a/src/sdl-audio.ads
+++ b/src/sdl-audio.ads
@@ -34,7 +34,7 @@ package SDL.Audio is
    Audio_Error : exception;
 
    --  Audio drivers.
-   -- TODO: SDL3 - Removes Initialise/Finalise
+   --  TODO: SDL3 - Removes Initialise/Finalise
    function Initialise (Name : in String := "") return Boolean;
 
    procedure Finalise with

--- a/src/sdl-events.ads
+++ b/src/sdl-events.ads
@@ -28,7 +28,6 @@
 --    I wanted to experiment with the event system and possibly hide all this and create an abstraction in another
 --    task so as to separate out the events from the main window. This could change. I really don't know yet.
 --------------------------------------------------------------------------------------------------------------------
-with Ada.Unchecked_Conversion;
 
 package SDL.Events is
    pragma Preelaborate;

--- a/src/sdl-video-palettes.ads
+++ b/src/sdl-video-palettes.ads
@@ -49,6 +49,8 @@ package SDL.Video.Palettes is
 
    Null_Colour : constant Colour := (others => <>);
 
+   pragma Warnings (Off, "8 bits of * unused", Reason => "padding");
+
    type RGB_Colour is
       record
          Red   : Colour_Component := Colour_Component'First;
@@ -59,6 +61,8 @@ package SDL.Video.Palettes is
      Size       => Colour_Component'Size * 4;
 
    Null_RGB_Colour : constant RGB_Colour := (others => <>);
+
+   pragma Warnings (On, "8 bits of * unused");
 
    --  Cursor type for our iterator.
    type Cursor is private;

--- a/src/sdl-video-pixel_formats.ads
+++ b/src/sdl-video-pixel_formats.ads
@@ -25,7 +25,6 @@
 --  Description of various pixel formats.
 --------------------------------------------------------------------------------------------------------------------
 with Ada.Characters.Latin_1;
-with Ada.Unchecked_Conversion;
 with Interfaces;
 with Interfaces.C;
 with SDL.Video.Palettes;

--- a/src/sdl-video-rectangles.adb
+++ b/src/sdl-video-rectangles.adb
@@ -20,7 +20,6 @@
 --     3. This notice may not be removed or altered from any source
 --     distribution.
 --------------------------------------------------------------------------------------------------------------------
-with Ada.Unchecked_Conversion;
 with SDL.Error;
 
 package body SDL.Video.Rectangles is

--- a/src/sdl-video-surfaces.ads
+++ b/src/sdl-video-surfaces.ads
@@ -211,18 +211,18 @@ private
    --  Internal_Surfaces are allowed to be manipulated by the user, but this is protected behind the following inlines.
    type Internal_Surface is
       record
-         Flags           : Surface_Flags;           --  Internal, don't touch.
-         Pixel_Format    : Pixel_Formats.Pixel_Format_Access;
-         Width           : SDL.Dimension;
-         Height          : SDL.Dimension;
-         Pitch           : C.int;
-         Pixels          : System.Address;          --  Pixel data.
-         User_Data       : User_Data_Pointer;
-         Locked          : C.int;                   --  Internal, don't touch.
-         Lock_Data       : System.Address;          --  Internal, don't touch.
-         Clip_Rectangle  : Rectangles.Rectangle;
-         Blit_Map        : System.Address;          --  Internal, don't touch.
-         Reference_Count : C.int;
+         Flags           : Surface_Flags := SW_Surface;            --  Internal, don't touch.
+         Pixel_Format    : Pixel_Formats.Pixel_Format_Access := null;
+         Width           : SDL.Dimension := 0;
+         Height          : SDL.Dimension := 0;
+         Pitch           : C.int := 0;
+         Pixels          : System.Address := System.Null_Address;  --  Pixel data.
+         User_Data       : User_Data_Pointer := null;
+         Locked          : C.int := 0;                             --  Internal, don't touch.
+         Lock_Data       : System.Address := System.Null_Address;  --  Internal, don't touch.
+         Clip_Rectangle  : Rectangles.Rectangle := (others => <>);
+         Blit_Map        : System.Address := System.Null_Address;  --  Internal, don't touch.
+         Reference_Count : C.int := 0;
       end record with
      Convention => C;
 

--- a/src/sdl-video-textures.adb
+++ b/src/sdl-video-textures.adb
@@ -22,7 +22,6 @@
 --------------------------------------------------------------------------------------------------------------------
 with Interfaces.C;
 with System;
-with Ada.Unchecked_Conversion;
 with SDL.Error;
 
 package body SDL.Video.Textures is

--- a/test/audio_support.adb
+++ b/test/audio_support.adb
@@ -1,5 +1,3 @@
-with Ada.Unchecked_Conversion;
-
 package body Audio_Support is
 
    procedure Callback

--- a/test/hello_world.adb
+++ b/test/hello_world.adb
@@ -48,7 +48,7 @@ begin
          end loop;
       end loop Main;
 
-      -- Clean up and exit.
+      --  Clean up and exit.
       W.Finalize;
       SDL.Finalise;
    end if;

--- a/test/load_surface.adb
+++ b/test/load_surface.adb
@@ -1,4 +1,3 @@
-with Ada.Unchecked_Conversion;
 with Interfaces.C;
 with SDL;
 with SDL.Events.Events;

--- a/test/surface.adb
+++ b/test/surface.adb
@@ -1,4 +1,3 @@
-with Ada.Unchecked_Conversion;
 with SDL;
 with SDL.Events.Events;
 with SDL.Events.Keyboards;


### PR DESCRIPTION
- Removed unused with lines.
- Adjusted spacing on comments (GNAT coding style).
- Added pragma to tell GNAT to ignore RGB pixel padding bits.
- Provided default values for SDL.Video.Surfaces.Internal_Surface, fixing warning about initializing aggregate Null_Internal_Surface.