### PR TITLE
Switch from dynamic to static elaboration model.

### DIFF
--- a/build/gnat/sdlada.gpr
+++ b/build/gnat/sdlada.gpr
@@ -31,7 +31,7 @@ library project SDLAda is
    package Compiler is
       Common_Switches := ("-ffunction-sections", "-fdata-sections");
       C_Switches      := ();
-      Ada_Switches    := ("-gnat2012", "-gnata", "-gnato", "-gnatE", "-gnatwa",
+      Ada_Switches    := ("-gnat2012", "-gnata", "-gnato", "-gnatwa",
                           "-gnaty", "-gnaty-s", "-gnatyO", "-gnatyM120", "-gnatyx");
 
       case Mode is

--- a/build/gnat/tools.gpr
+++ b/build/gnat/tools.gpr
@@ -11,7 +11,7 @@ project Tools is
    package Compiler is
       C_Switches   := ("-ffunction-sections", "-fdata-sections");
       Ada_Switches := ("-ffunction-sections", "-fdata-sections",
-                       "-gnat2012", "-gnata", "-gnato", "-gnatE", "-gnatwa",
+                       "-gnat2012", "-gnata", "-gnato", "-gnatwa",
                        "-gnaty", "-gnaty-s", "-gnatyO", "-gnatyM120", "-gnatyO");
 
       case Mode is

--- a/src/image/sdl-images-io.ads
+++ b/src/image/sdl-images-io.ads
@@ -30,6 +30,8 @@ with SDL.Video.Textures;
 with SDL.RWops;
 
 package SDL.Images.IO is
+   pragma Preelaborate;
+
    --  TODO: I don't like the idea of leaving the freeing of the Source to the programmer, this is error prone and will
    --        cause leaks! I would prefer the RWops object be controlled.
    procedure Create (Surface : in out Video.Surfaces.Surface; File_Name : in String);

--- a/src/image/sdl-images-versions.ads
+++ b/src/image/sdl-images-versions.ads
@@ -27,6 +27,8 @@
 with SDL.Versions;
 
 package SDL.Images.Versions is
+   pragma Elaborate_Body;
+
    --  These allow the user to determine which version of SDLAda_Image they compiled with.
    Compiled_Major : constant SDL.Versions.Version_Level with
      Import        => True,

--- a/src/image/sdl-images.ads
+++ b/src/image/sdl-images.ads
@@ -27,6 +27,8 @@
 with Interfaces.C;
 
 package SDL.Images is
+   pragma Pure;
+
    package C renames Interfaces.C;
 
    Image_Error : exception;

--- a/src/sdl-audio-devices.ads
+++ b/src/sdl-audio-devices.ads
@@ -33,6 +33,7 @@ generic
    type Buffer_Index is (<>);
    type Buffer_Type is array (Buffer_Index range <>) of Frame_Type;
 package SDL.Audio.Devices is
+   pragma Elaborate_Body;
 
    Audio_Device_Error : exception;
 

--- a/src/sdl-cpus.ads
+++ b/src/sdl-cpus.ads
@@ -25,7 +25,7 @@
 --  Platform CPU information retrieval.
 --------------------------------------------------------------------------------------------------------------------
 package SDL.CPUS is
-   pragma Preelaborate;
+   pragma Pure;
 
    --  TODO: Add a subprogram to return CPU architecture as not all platforms will have the same one, i.e.
    --  Android on ARM, MIPS, x86.

--- a/src/sdl-events-controllers.ads
+++ b/src/sdl-events-controllers.ads
@@ -27,7 +27,7 @@
 with SDL.Events.Joysticks;
 
 package SDL.Events.Controllers is
-   pragma Preelaborate;
+   pragma Pure;
 
    --  Game controller events.
    Axis_Motion     : constant Event_Types := 16#0000_0650#;

--- a/src/sdl-events-joysticks-game_controllers.ads
+++ b/src/sdl-events-joysticks-game_controllers.ads
@@ -26,7 +26,7 @@
 --------------------------------------------------------------------------------------------------------------------
 
 package SDL.Events.Joysticks.Game_Controllers is
-   pragma Preelaborate;
+   pragma Pure;
 
    type Axes is (Invalid,
                  Left_X,

--- a/src/sdl-events-joysticks.ads
+++ b/src/sdl-events-joysticks.ads
@@ -25,7 +25,7 @@
 --  Joystick specific events.
 --------------------------------------------------------------------------------------------------------------------
 package SDL.Events.Joysticks is
-   pragma Preelaborate;
+   pragma Pure;
 
    --  Joystick events.
    Axis_Motion       : constant Event_Types := 16#0000_0600#;

--- a/src/sdl-events-touches.ads
+++ b/src/sdl-events-touches.ads
@@ -32,7 +32,7 @@
 with Interfaces.C;
 
 package SDL.Events.Touches is
-   pragma Preelaborate;
+   pragma Pure;
 
    --  Touch events.
    Finger_Down                : constant Event_Types := 16#0000_0700#;

--- a/src/sdl-events.ads
+++ b/src/sdl-events.ads
@@ -31,7 +31,7 @@
 with Ada.Unchecked_Conversion;
 
 package SDL.Events is
-   pragma Preelaborate;
+   pragma Pure;
 
    type Event_Types is mod 2 ** 32 with
      Convention => C;

--- a/src/sdl-inputs-mice-cursors.ads
+++ b/src/sdl-inputs-mice-cursors.ads
@@ -26,6 +26,8 @@ with Ada.Finalization;
 private with SDL.C_Pointers;
 
 package SDL.Inputs.Mice.Cursors is
+   pragma Preelaborate;
+
    --  Don't confuse this package with any type of Ada iterator, this is for visual mouse cursors.
 
    type Cursor is new Ada.Finalization.Limited_Controlled with private;

--- a/src/sdl-inputs.ads
+++ b/src/sdl-inputs.ads
@@ -23,5 +23,5 @@
 --  SDL.Inputs
 --------------------------------------------------------------------------------------------------------------------
 package SDL.Inputs is
-   pragma Preelaborate;
+   pragma Pure;
 end SDL.Inputs;

--- a/src/sdl-platform.ads
+++ b/src/sdl-platform.ads
@@ -25,7 +25,7 @@
 --  Determine which platform we are running on.
 --------------------------------------------------------------------------------------------------------------------
 package SDL.Platform is
-   pragma Preelaborate;
+   pragma Pure;
 
    type Platforms is (Windows, Mac_OS_X, Linux, BSD, iOS, Android);
 

--- a/src/sdl-power.ads
+++ b/src/sdl-power.ads
@@ -25,7 +25,7 @@
 --  Battery access on the target platform.
 --------------------------------------------------------------------------------------------------------------------
 package SDL.Power is
-   pragma Preelaborate;
+   pragma Pure;
 
    type State is
      (Unknown,    --  Cannot determine power status.

--- a/src/sdl-timers.ads
+++ b/src/sdl-timers.ads
@@ -27,7 +27,7 @@
 with Interfaces;
 
 package SDL.Timers is
-   pragma Preelaborate;
+   pragma Pure;
 
    type Milliseconds is new Interfaces.Unsigned_32;
 

--- a/src/sdl.ads
+++ b/src/sdl.ads
@@ -27,7 +27,7 @@
 with Interfaces.C;
 
 package SDL is
-   pragma Preelaborate;
+   pragma Pure;
 
    package C renames Interfaces.C;
 

--- a/src/ttf/sdl-ttfs-makers.ads
+++ b/src/ttf/sdl-ttfs-makers.ads
@@ -28,6 +28,8 @@
 with SDL.RWops;
 
 package SDL.TTFs.Makers is
+   pragma Preelaborate;
+
    procedure Create (Font       : in out Fonts;
                      File_Name  : in String;
                      Point_Size : in Point_Sizes;

--- a/src/ttf/sdl-ttfs-versions.ads
+++ b/src/ttf/sdl-ttfs-versions.ads
@@ -27,6 +27,8 @@
 with SDL.Versions;
 
 package SDL.TTFs.Versions is
+   pragma Elaborate_Body;
+
    --  These allow the user to determine which version of SDLAda_TTF they compiled with.
    Compiled_Major : constant SDL.Versions.Version_Level with
      Import        => True,

--- a/src/ttf/sdl-ttfs.ads
+++ b/src/ttf/sdl-ttfs.ads
@@ -31,6 +31,8 @@ with SDL.Video.Palettes;
 with SDL.Video.Surfaces;
 
 package SDL.TTFs is
+   pragma Preelaborate;
+
    package UTF_Strings renames Ada.Strings.UTF_Encoding;
    package C renames Interfaces.C;
 


### PR DESCRIPTION
The "-gnatE" compiler switch for dynamic elaboration model isn't compatible with SPARK restrictions. It also doesn't appear to be necessary since there aren't any circularities in the library.

Removed the "-gnatE" switch from sdlada.gpr and tools.gpr and then, to minimize the chances of any ABE (access-before-elaboration) issues, add "pragma Pure", "pragma Preelaborate", or "pragma Elaborate_Body" to package specs where possible. This shouldn't affect any library clients.

The only package spec where I couldn't add any of the above listed pragmas was SDL.Audio.Sample_Formats, which defines several sample format constants by assignment from earlier-defined constants. That package doesn't have a body, so pragma Elaborate_Body doesn't work, and Preelaborate doesn't work because a "static expression must have scalar or string type (RM 4.9(2))" in a preelaborated unit.