### PR TITLE
Update samples to delay using fixed frame rates.

### DIFF
--- a/test/hello_world.adb
+++ b/test/hello_world.adb
@@ -1,3 +1,5 @@
+with Ada.Real_Time; use Ada.Real_Time;
+
 with SDL;
 with SDL.Events.Events;
 with SDL.Log;
@@ -12,6 +14,12 @@ procedure Hello_World is
    Renderer         : SDL.Video.Renderers.Renderer;
    Texture          : SDL.Video.Textures.Texture;
    Event            : SDL.Events.Events.Events;
+
+   Loop_Start_Time_Goal : Ada.Real_Time.Time;
+
+   Frame_Duration : constant Ada.Real_Time.Time_Span :=
+     Ada.Real_Time.Microseconds (16_667);
+   --  60 Hz refresh rate (set to anything you like)
 
    use type SDL.Events.Event_Types;
 begin
@@ -36,7 +44,14 @@ begin
          Kind     => SDL.Video.Textures.Streaming,
          Size     => W_Size);
 
+      --  Set next frame delay target using monotonic clock time
+      Loop_Start_Time_Goal := Ada.Real_Time.Clock;
+
       Main : loop
+         --  Limit event loop to 60 Hz using realtime "delay until"
+         Loop_Start_Time_Goal := Loop_Start_Time_Goal + Frame_Duration;
+         delay until Loop_Start_Time_Goal;
+
          while SDL.Events.Events.Poll (Event) loop
             if Event.Common.Event_Type = SDL.Events.Quit then
                exit Main;

--- a/test/load_surface.adb
+++ b/test/load_surface.adb
@@ -1,3 +1,4 @@
+with Ada.Real_Time; use Ada.Real_Time;
 with Ada.Unchecked_Conversion;
 with Interfaces.C;
 with SDL;
@@ -50,6 +51,12 @@ begin
             Height => Image_Area.Height / 4);
          Finished           : Boolean := False;
 
+         Loop_Start_Time_Goal : Ada.Real_Time.Time;
+
+         Frame_Duration : constant Ada.Real_Time.Time_Span :=
+           Ada.Real_Time.Microseconds (16_667);
+         --  60 Hz refresh rate (set to anything you like)
+
          use type SDL.Events.Keyboards.Key_Codes;
       begin
          Window_Surface := W.Get_Surface;
@@ -71,7 +78,14 @@ begin
                                                                                     Width  => Image_Area.Width / 2,
                                                                                     Height => Image_Area.Height / 2));
 
+         --  Set next frame delay target using monotonic clock time
+         Loop_Start_Time_Goal := Ada.Real_Time.Clock;
+
          loop
+            --  Limit event loop to 60 Hz using realtime "delay until"
+            Loop_Start_Time_Goal := Loop_Start_Time_Goal + Frame_Duration;
+            delay until Loop_Start_Time_Goal;
+
             W.Update_Surface;
 
             while SDL.Events.Events.Poll (Event) loop

--- a/test/mouse.adb
+++ b/test/mouse.adb
@@ -1,3 +1,5 @@
+with Ada.Real_Time; use Ada.Real_Time;
+
 with SDL;
 with SDL.Events.Events;
 with SDL.Events.Keyboards;
@@ -14,6 +16,13 @@ procedure Mouse is
    W           : SDL.Video.Windows.Window;
    Renderer    : SDL.Video.Renderers.Renderer;
    Texture     : SDL.Video.Textures.Texture;
+
+   Loop_Start_Time_Goal : Ada.Real_Time.Time;
+
+   Frame_Duration : constant Ada.Real_Time.Time_Span :=
+     Ada.Real_Time.Microseconds (16_667);
+   --  60 Hz refresh rate (set to anything you like)
+
 begin
    SDL.Log.Set (Category => SDL.Log.Application, Priority => SDL.Log.Debug);
 
@@ -40,7 +49,14 @@ begin
          Warp_Rel    : Boolean := True;
          Warp_Screen : Boolean := False;
       begin
+         --  Set next frame delay target using monotonic clock time
+         Loop_Start_Time_Goal := Ada.Real_Time.Clock;
+
          loop
+            --  Limit event loop to 60 Hz using realtime "delay until"
+            Loop_Start_Time_Goal := Loop_Start_Time_Goal + Frame_Duration;
+            delay until Loop_Start_Time_Goal;
+
             while SDL.Events.Events.Poll (Event) loop
                case Event.Common.Event_Type is
                   when SDL.Events.Quit =>

--- a/test/stream.adb
+++ b/test/stream.adb
@@ -1,4 +1,4 @@
-with Ada.Calendar;
+with Ada.Real_Time; use Ada.Real_Time;
 with Ada.Text_IO.Text_Streams;
 with Ada.Unchecked_Conversion;
 with Interfaces.C;
@@ -79,16 +79,15 @@ procedure Stream is
    procedure Lock is new SDL.Video.Textures.Lock (Pixel_Pointer_Type => SDL.Video.Pixels.ARGB_8888_Access.Pointer);
 
    use type SDL.Video.Pixels.ARGB_8888_Access.Pointer;
-   use type Ada.Calendar.Time;
 
    --  This uses the same algorithm as the original teststream.c. It copies 1 pixel at a time, indexing into the moose
    --  palette using the data from moose.dat.
    procedure Update_Texture_1 (Pointer : in SDL.Video.Pixels.ARGB_8888_Access.Pointer) is
-      Start_Time       : Ada.Calendar.Time;
-      End_Time         : Ada.Calendar.Time;
+      Start_Time       : Ada.Real_Time.Time;
+      End_Time         : Ada.Real_Time.Time;
       Colour           : SDL.Video.Palettes.RGB_Colour;
    begin
-      Start_Time := Ada.Calendar.Clock;
+      Start_Time := Ada.Real_Time.Clock;
 
       for Y in 1 .. Moose_Size.Height loop
          declare
@@ -108,8 +107,8 @@ procedure Stream is
          end;
       end loop;
 
-      End_Time := Ada.Calendar.Clock;
-      SDL.Log.Put_Debug ("Update_Texture_1 took " & Duration'Image (End_Time - Start_Time) & " seconds.");
+      End_Time := Ada.Real_Time.Clock;
+      SDL.Log.Put_Debug ("Update_Texture_1 took " & To_Duration (End_Time - Start_Time)'Img & " seconds.");
    end Update_Texture_1;
 
    type Texture_2D_Array is array (SDL.Dimension range <>, SDL.Dimension range <>) of
@@ -128,13 +127,13 @@ procedure Stream is
       function To_Address is new Ada.Unchecked_Conversion (Source => SDL.Video.Pixels.ARGB_8888_Access.Pointer,
                                                            Target => System.Address);
 
-      Start_Time       : Ada.Calendar.Time;
-      End_Time         : Ada.Calendar.Time;
+      Start_Time       : Ada.Real_Time.Time;
+      End_Time         : Ada.Real_Time.Time;
       Colour           : SDL.Video.Palettes.RGB_Colour;
       Actual_Pixels    : Texture_2D_Array (1 .. Moose_Size.Height, 1 .. Moose_Size.Width) with
         Address => To_Address (Pixels);
    begin
-      Start_Time := Ada.Calendar.Clock;
+      Start_Time := Ada.Real_Time.Clock;
 
       for Y in 1 .. Moose_Size.Height loop
          for X in 1 .. Moose_Size.Width loop
@@ -147,8 +146,8 @@ procedure Stream is
          end loop;
       end loop;
 
-      End_Time := Ada.Calendar.Clock;
-      SDL.Log.Put_Debug ("Update_Texture_2 took " & Duration'Image (End_Time - Start_Time) & " seconds.");
+      End_Time := Ada.Real_Time.Clock;
+      SDL.Log.Put_Debug ("Update_Texture_2 took " & To_Duration (End_Time - Start_Time)'Img & " seconds.");
    end Update_Texture_2;
 
    type Cached_Moose_Frame_Array is array (Moose_Frames) of
@@ -270,17 +269,17 @@ begin
             function To_Address is new Ada.Unchecked_Conversion (Source => SDL.Video.Pixels.ARGB_8888_Access.Pointer,
                                                                  Target => System.Address);
 
-            Start_Time    : Ada.Calendar.Time;
-            End_Time      : Ada.Calendar.Time;
+            Start_Time    : Ada.Real_Time.Time;
+            End_Time      : Ada.Real_Time.Time;
             Actual_Pixels : Texture_2D_Array (1 .. Moose_Size.Height, 1 .. Moose_Size.Width) with
               Address => To_Address (Pixels);
          begin
-            Start_Time := Ada.Calendar.Clock;
+            Start_Time := Ada.Real_Time.Clock;
 
             Actual_Pixels := Cache (Moose_Frame);
 
-            End_Time := Ada.Calendar.Clock;
-            SDL.Log.Put_Debug ("Update_Texture_3 took " & Duration'Image (End_Time - Start_Time) & " seconds.");
+            End_Time := Ada.Real_Time.Clock;
+            SDL.Log.Put_Debug ("Update_Texture_3 took " & To_Duration (End_Time - Start_Time)'Img & " seconds.");
          end Update_Texture_3;
 
          Texture.Unlock;

--- a/test/surface_direct_access.adb
+++ b/test/surface_direct_access.adb
@@ -1,3 +1,4 @@
+with Ada.Real_Time; use Ada.Real_Time;
 with Interfaces.C.Pointers;
 with SDL.Events.Events;
 with SDL.Events.Keyboards;
@@ -165,6 +166,12 @@ begin
          Event            : SDL.Events.Events.Events;
          Finished         : Boolean := False;
 
+         Loop_Start_Time_Goal : Ada.Real_Time.Time;
+
+         Frame_Duration : constant Ada.Real_Time.Time_Span :=
+           Ada.Real_Time.Microseconds (16_667);
+         --  60 Hz refresh rate (set to anything you like)
+
          use type SDL.Events.Keyboards.Key_Codes;
       begin
          SDL.Video.Surfaces.Makers.Create (Self => S,
@@ -182,7 +189,14 @@ begin
          Window_Surface.Blit (S);
          W.Update_Surface;
 
+         --  Set next frame delay target using monotonic clock time
+         Loop_Start_Time_Goal := Ada.Real_Time.Clock;
+
          loop
+            --  Limit event loop to 60 Hz using realtime "delay until"
+            Loop_Start_Time_Goal := Loop_Start_Time_Goal + Frame_Duration;
+            delay until Loop_Start_Time_Goal;
+
             while SDL.Events.Events.Poll (Event) loop
                case Event.Common.Event_Type is
                   when SDL.Events.Quit =>

--- a/test/test.adb
+++ b/test/test.adb
@@ -1,3 +1,4 @@
+with Ada.Real_Time; use Ada.Real_Time;
 with SDL;
 with SDL.Error;
 with SDL.Events.Events;
@@ -145,10 +146,23 @@ begin
          Event    : SDL.Events.Events.Events;
          Finished : Boolean := False;
 
+         Loop_Start_Time_Goal : Ada.Real_Time.Time;
+
+         Frame_Duration : constant Ada.Real_Time.Time_Span :=
+           Ada.Real_Time.Microseconds (6_944);
+         --  144 Hz refresh rate
+
          use type SDL.Events.Keyboards.Key_Codes;
          use type SDL.Events.Windows.Window_Event_ID;
       begin
+         --  Set next frame delay target using monotonic clock time
+         Loop_Start_Time_Goal := Ada.Real_Time.Clock;
+
          loop
+            --  Limit event loop to 144 Hz using realtime "delay until"
+            Loop_Start_Time_Goal := Loop_Start_Time_Goal + Frame_Duration;
+            delay until Loop_Start_Time_Goal;
+
             while SDL.Events.Events.Poll (Event) loop
                case Event.Common.Event_Type is
                   when SDL.Events.Quit =>


### PR DESCRIPTION
Update sample apps to initialize a frame delay goal Ada.Real_Time.Time variable from Ada.Real_Time.Clock and then "delay until" subsequent frames for each iteration of the event loop, using a fixed frame rate.

The moose animation in test/stream2 now listens for key down and key up events and changes the animation frame every 4 iterations of the 144 Hz event loop if either left or right cursor key is down (but not both), for an animation speed of 36 Hz.

The modified sample apps no longer use 100% CPU and should be more representative of real games, video players, emulators, etc..