### PR TITLE
Add proper support for (macOS) Homebrew, MacPorts.

### DIFF
--- a/alire.toml
+++ b/alire.toml
@@ -22,7 +22,9 @@ project-files = ["build/gnat/sdlada.gpr"] #, "build/gnat/"]
 [gpr-set-externals.'case(os)']
   linux   = { SDL_PLATFORM = "linux" }
   windows = { SDL_PLATFORM = "windows" }
-  # macos   = { SDL_PLATFORM = "macos_homebrew" }
+[gpr-set-externals.'case(distribution)']
+  homebrew = { SDL_PLATFORM = "macos_homebrew" }
+  macports = { SDL_PLATFORM = "macos_ports" }
 
 [[actions]]
   type = "pre-build"


### PR DESCRIPTION
 This change allows macOS users  to build sdlada over either Homebrew or MacPorts.

Note, it assumes that Alire won't need to support Homebrew over Linux. If that happens, we'll need to seek advice on specifying multi-discriminant choices.

[Safari's spellcheck wants to correct sdlada to salads :-) ]