### PR TITLE
Proposal for sorting out include paths (Windows & macOS)

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -1,0 +1,32 @@
+---
+
+name: CI Linux
+
+on:
+  pull_request:
+
+jobs:
+  build:
+    name: CI on linux
+
+    runs-on: ubuntu-latest
+
+    steps:
+    -
+      name: Checkout
+      uses: actions/checkout@v2
+    -
+      name: alire-project/setup-alire
+      uses: alire-project/setup-alire@v1
+    -
+      name: Install toolchain
+      run: |
+        alr --non-interactive config --global --set toolchain.assistant false
+        alr --non-interactive toolchain --install gnat_native
+        alr --non-interactive toolchain --install gprbuild
+        alr --non-interactive toolchain --select gnat_native
+        alr --non-interactive toolchain --select gprbuild
+    -
+      name: Build and run
+      run: |
+        alr --non-interactive build

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -27,6 +27,13 @@ jobs:
         alr --non-interactive toolchain --select gnat_native
         alr --non-interactive toolchain --select gprbuild
     -
+      name: Install SDL2 components
+      run: |
+        brew install sdl2
+        brew install sdl2_image
+        brew install sdl2_mixer
+        brew install sdl2_ttf
+    -
       name: Build and run
       run: |
         eval $(brew shellenv)

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -1,0 +1,36 @@
+---
+
+name: CI macOS
+
+on:
+  pull_request:
+
+jobs:
+  build:
+    name: CI on macOS
+
+    runs-on: macos-latest
+
+    steps:
+    -
+      name: Checkout
+      uses: actions/checkout@v2
+    -
+      name: alire-project/setup-alire
+      uses: alire-project/setup-alire@v1
+    -
+      name: Install toolchain
+      run: |
+        alr --non-interactive config --global --set toolchain.assistant false
+        alr --non-interactive toolchain --install gnat_native
+        alr --non-interactive toolchain --install gprbuild
+        alr --non-interactive toolchain --select gnat_native
+        alr --non-interactive toolchain --select gprbuild
+    -
+      name: Build and run
+      run: |
+        eval $(brew shellenv)
+        export C_INCLUDE_PATH=$HOMEBREW_PREFIX/include
+        export CPP_INCLUDE_PATH=$HOMEBREW_PREFIX/include
+        export LIBRARY_PATH=$HOMEBREW_PREFIX/lib
+        alr --non-interactive build

--- a/.github/workflows/ci-windows.yaml
+++ b/.github/workflows/ci-windows.yaml
@@ -1,0 +1,32 @@
+---
+
+name: CI Windows
+
+on:
+  pull_request:
+
+jobs:
+  build:
+    name: CI on windows
+
+    runs-on: windows-latest
+
+    steps:
+    -
+      name: Checkout
+      uses: actions/checkout@v2
+    -
+      name: alire-project/setup-alire
+      uses: alire-project/setup-alire@v1
+    -
+      name: Install toolchain
+      run: |
+        alr --non-interactive config --global --set toolchain.assistant false
+        alr --non-interactive toolchain --install gnat_native
+        alr --non-interactive toolchain --install gprbuild
+        alr --non-interactive toolchain --select gnat_native
+        alr --non-interactive toolchain --select gprbuild
+    -
+      name: Build and run
+      run: |
+        alr --non-interactive build

--- a/alire.toml
+++ b/alire.toml
@@ -22,9 +22,10 @@ project-files = ["build/gnat/sdlada.gpr"] #, "build/gnat/"]
 [gpr-set-externals.'case(os)']
   linux   = { SDL_PLATFORM = "linux" }
   windows = { SDL_PLATFORM = "windows" }
-[gpr-set-externals.'case(distribution)']
-  homebrew = { SDL_PLATFORM = "macos_homebrew" }
-  macports = { SDL_PLATFORM = "macos_ports" }
+  macos   = { SDL_PLATFORM = "macosx" }
+# [gpr-set-externals.'case(distribution)']
+#   homebrew = { SDL_PLATFORM = "macos_homebrew" }
+#   macports = { SDL_PLATFORM = "macos_ports" }
 
 [[actions]]
   type = "pre-build"

--- a/src/image/version_images.c
+++ b/src/image/version_images.c
@@ -1,15 +1,7 @@
 /***********************************************************************************************************************
  * This source code is subject to the Zlib license, see the LICENCE file in the root of this directory.
  **********************************************************************************************************************/
-#ifdef __APPLE__
-    #if defined(SDL_HOMEBREW) || defined(SDL_MACPORTS)
-        #include <SDL2/SDL_image.h>
-    #else
-        #include <SDL2_image/SDL_image.h>
-    #endif
-#else
-#include <SDL_image.h>
-#endif
+#include <SDL2/SDL_image.h>
 
 /* We need to define some constants here so we can get access to the values that in #define form from Ada.
  */

--- a/src/mixer/version_mixer.c
+++ b/src/mixer/version_mixer.c
@@ -1,11 +1,7 @@
 /***********************************************************************************************************************
  *  This source code is subject to the Zlib license, see the LICENCE file in the root of this directory.
  **********************************************************************************************************************/
-#ifdef __APPLE__
-#include <SDL2_mixer/SDL_mixer.h>
-#else
-#include <SDL_mixer.h>
-#endif
+#include <SDL2/SDL_mixer.h>
 
 /* We need to define some constants here so we can get access to the values that in #define form from Ada.
  */

--- a/src/ttf/version_ttf.c
+++ b/src/ttf/version_ttf.c
@@ -1,15 +1,7 @@
 /***********************************************************************************************************************
  *  This source code is subject to the Zlib license, see the LICENCE file in the root of this directory.
  **********************************************************************************************************************/
-#ifdef __APPLE__
-    #if defined(SDL_HOMEBREW) || defined(SDL_MACPORTS)
-        #include <SDL2/SDL_ttf.h>
-    #else
-        #include <SDL2_ttf/SDL_ttf.h>
-    #endif
-#else
-#include <SDL_ttf.h>
-#endif
+#include <SDL2/SDL_ttf.h>
 
 /* We need to define some constants here so we can get access to the values that in #define form from Ada.
  */

--- a/src/version.c
+++ b/src/version.c
@@ -1,11 +1,7 @@
 /***********************************************************************************************************************
  *  This source code is subject to the Zlib license, see the LICENCE file in the root of this directory.
  **********************************************************************************************************************/
-#ifdef __APPLE__
 #include <SDL2/SDL.h>
-#else
-#include <SDL.h>
-#endif
 
 /* We need to define some constants here so we can get access to the values that in #define form from Ada.
  */


### PR DESCRIPTION
The "include path" part of this change consists of removing the framework aspects of the include paths in `version*.c`, with the effect that we only need one `include` per file. It does make it hard to support framework builds; you might prefer an
```
# if defined (MACOS_FRAMEWORKS)
  # include <SDL2_image/SDL_image.h>
# else 
  # include <SDL2/SDL_image.h>
# endif
```
style. Would still need to do something about `-F` etc, but that could be left up to the punters with the odd hint? - not, I think, one we’d need to cater for under Alire.

I also included some simple CI 'on pull request' workflows. They all run with alr 1.2.2, hence the need to manually install the HB components on the macOS workflow. I’m not sure how to work round this one?